### PR TITLE
APIGW-799 VDB template parameter template_id throws api error

### DIFF
--- a/docs/resources/vdb.md
+++ b/docs/resources/vdb.md
@@ -60,9 +60,13 @@ resource "delphix_vdb" "vdb_name" {
 
 * `truncate_log_on_checkpoint` - (Optional) Whether to truncate log on checkpoint (ASE only).
 
-* `username` - (Optional) [Updatable] The name of the privileged user to run the provision operation (Oracle Only).
+* `os_username` - (Optional) The name of the privileged user to run the provision operation (Oracle Only).
 
-* `password` - (Optional) [Updatable] The password of the privileged user to run the provision operation (Oracle Only).
+* `os_password` - (Optional) The password of the privileged user to run the provision operation (Oracle Only).
+
+* `db_username` - (Optional) [Updatable] The username of the database user (Oracle, ASE Only). Only for update.
+
+* `db_password` - (Optional) [Updatable] The password of the database user (Oracle, ASE Only). Only for update.
 
 * `environment_id` - (Optional) The ID of the target environment where to provision the VDB. If repository_id unambigously identifies a repository, this is unnecessary and ignored. Otherwise, a compatible repository is randomly selected on the environment.
 

--- a/examples/vdb/main.tf
+++ b/examples/vdb/main.tf
@@ -9,8 +9,8 @@ terraform {
 
 provider "delphix" {
   tls_insecure_skip = true
-  key               = "1.089N1yoNUoHis8cJqA6BHRaf5OnS1HWmDAlQgxzNmhxNESamd9T4CNuLyvjw8eVF"
-  host              = "localhost"
+  key               = "1.XXXX"
+  host              = "HOSTNAME"
 }
 
 resource "delphix_vdb" "vdb_name2" {

--- a/examples/vdb/main.tf
+++ b/examples/vdb/main.tf
@@ -13,16 +13,37 @@ provider "delphix" {
   host              = "HOSTNAME"
 }
 
-resource "delphix_vdb" "vdb_name2" {
+resource "delphix_vdb" "vdb_name" {
   provision_type         = "snapshot"
   auto_select_repository = true
   source_data_id         = "dsource"
-  vdb_name = "vdb-from-tf2"
-  oracle_instance_name = "vdbtf"
-  database_name = "vdbtf"
-  unique_name = "vdbtf"
-  db_username = "oracle"
-  db_password = "oracle"
-  template_id = "myTemplate"
-  listener_ids = ["LISTENER"]
+
+  pre_refresh {
+    name    = "n"
+    command = "time"
+    shell   = "bash"
+  }
+  pre_refresh {
+    name    = "n2"
+    command = "time"
+    shell   = "bash"
+  }
+}
+
+resource "delphix_vdb" "vdb_name2" {
+  provision_type         = "timestamp"
+  auto_select_repository = true
+  source_data_id         = "dsource2"
+  timestamp              = "2021-05-01T08:51:34.148000+00:00"
+
+  post_refresh {
+    name    = "n"
+    command = "time"
+    shell   = "bash"
+  }
+  post_refresh {
+    name    = "n2"
+    command = "time"
+    shell   = "bash"
+  }
 }

--- a/examples/vdb/main.tf
+++ b/examples/vdb/main.tf
@@ -9,41 +9,20 @@ terraform {
 
 provider "delphix" {
   tls_insecure_skip = true
-  key               = "1.XXXX"
-  host              = "HOSTNAME"
-}
-
-resource "delphix_vdb" "vdb_name" {
-  provision_type         = "snapshot"
-  auto_select_repository = true
-  source_data_id         = "dsource"
-
-  pre_refresh {
-    name    = "n"
-    command = "time"
-    shell   = "bash"
-  }
-  pre_refresh {
-    name    = "n2"
-    command = "time"
-    shell   = "bash"
-  }
+  key               = "1.089N1yoNUoHis8cJqA6BHRaf5OnS1HWmDAlQgxzNmhxNESamd9T4CNuLyvjw8eVF"
+  host              = "localhost"
 }
 
 resource "delphix_vdb" "vdb_name2" {
-  provision_type         = "timestamp"
+  provision_type         = "snapshot"
   auto_select_repository = true
-  source_data_id         = "dsource2"
-  timestamp              = "2021-05-01T08:51:34.148000+00:00"
-
-  post_refresh {
-    name    = "n"
-    command = "time"
-    shell   = "bash"
-  }
-  post_refresh {
-    name    = "n2"
-    command = "time"
-    shell   = "bash"
-  }
+  source_data_id         = "dsource"
+  vdb_name = "vdb-from-tf2"
+  oracle_instance_name = "vdbtf"
+  database_name = "vdbtf"
+  unique_name = "vdbtf"
+  db_username = "oracle"
+  db_password = "oracle"
+  template_id = "myTemplate"
+  listener_ids = ["LISTENER"]
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module terraform-provider-delphix
 
 go 1.17
 
+replace github.com/delphix/dct-sdk-go => /Users/ekaspi/repos/dct-sdk-go
+
 require github.com/delphix/dct-sdk-go v1.0.0-beta3
 
 require (
@@ -42,7 +44,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
-	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,7 @@ module terraform-provider-delphix
 
 go 1.17
 
-replace github.com/delphix/dct-sdk-go => /Users/ekaspi/repos/dct-sdk-go
-
-require github.com/delphix/dct-sdk-go v1.0.0-beta3
+require github.com/delphix/dct-sdk-go v1.0.0-beta4
 
 require (
 	github.com/agext/levenshtein v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/delphix/dct-sdk-go v1.0.0-beta3 h1:BqGqe/BeXB6jrk/tLBYDwrFh0qyncxTQqS87FRjWGdc=
-github.com/delphix/dct-sdk-go v1.0.0-beta3/go.mod h1:HCJfdjYSs5eo1FpU4mGTMmVzb5zHn9EP6IzqA/+MKC8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -381,8 +379,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a h1:qfl7ob3DIEs3Ml9oLuPwY2N04gymzAW04WsUQHIClgM=
-golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
+golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/delphix/dct-sdk-go v1.0.0-beta4 h1:+SWAh/6xbbgK/j4+ROeJTHmO6AYzbWK5VlM2jz11pLc=
+github.com/delphix/dct-sdk-go v1.0.0-beta4/go.mod h1:uzV6PTpsNHM24KKvNXaUgIfd5BDbq/fKM+M+PdSZ3JQ=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
The DCT VDBs API has changed in a non backwards compatible way (we shouldn't occur post-beta, but is accepted until GA).

In particular:
 * `vdb_name` is renamed to `name` for consistency
 * vdb provisioning is now taking `os_username` and `os_password` and vdb update is taking `db_username` and `db_password` to clearly differentiate
 * `template_id` and `listerners_ids` in vdb-update have been renamed for consistency
 * VDB update now returns a job_id to monitor progress

This change is therefore making terraform work with the latest DCT version (but breaks compatibility with DCT beta!). 

While I was there, I've removed the `job_id` parameter from the schema which was declared but unused/unset.

Testing
=====
Provisionned a VDB with and without specifying `os_username` and `os_password` and verified this was propagated to the engine (the VDB provisioned with `os_username` and `os_password` failed as I passed `root).
Tested updating the vdb_name, template, listeners and db_username/db_password and verified via the engine UI and engine access_log the values were set.

Ran VDB acceptance tests:
```
TESTARGS="-run TestAccVdb_provision_positive" make testacc
TF_ACC=1 go test $(go list ./... | grep -v 'vendor') -v -run TestAccVdb_provision_positive -timeout 120m   
?   	terraform-provider-delphix	[no test files]
=== RUN   TestAccVdb_provision_positive
[DELPHIX] [INFO] 2022/04/26 13:56:22 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:56:29 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:56:36 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:56:43 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:56:50 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:56:57 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:57:05 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:57:12 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:57:19 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:57:26 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:57:33 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:57:40 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:57:47 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:57:54 DCT-JobId:1-JOB-138 has Status:RUNNING
[DELPHIX] [INFO] 2022/04/26 13:58:01 DCT-JobId:1-JOB-138 has Status:COMPLETED
[DELPHIX] [INFO] 2022/04/26 13:58:01 Job result is COMPLETED
[DELPHIX] [INFO] 2022/04/26 13:58:02 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2022/04/26 13:58:03 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2022/04/26 13:58:04 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2022/04/26 13:58:09 Job result is STARTED
[DELPHIX] [INFO] 2022/04/26 13:58:10 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2022/04/26 13:58:12 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2022/04/26 13:58:24 DCT-JobId:1-JOB-141 has Status:COMPLETED
[DELPHIX] [INFO] 2022/04/26 13:58:24 Job result is COMPLETED
[DELPHIX] [INFO] 2022/04/26 13:59:05 [OK] Breaking poll - Status 404 reached.
--- PASS: TestAccVdb_provision_positive (182.68s)
PASS
ok  	terraform-provider-delphix/internal/provider	182.708s
```

Verified that provisioning a VDB cannot be done with `db_username`/`db_password` (values are inherited from the dsource at provisioning time).

Misc
====
This change depends on https://github.com/delphix/dct-sdk-go/pull/14, will update `go.mod` accordingly after having merged and released it.