### PR TITLE
Update DCT sdk go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module terraform-provider-delphix
 
 go 1.17
 
-require github.com/delphix/dct-sdk-go v1.0.0-beta5
+require github.com/delphix/dct-sdk-go v1.0.0-beta6
 
 require (
 	github.com/agext/levenshtein v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/delphix/dct-sdk-go v1.0.0-beta5 h1:tm4chfs13Do9Pc8MQdzmbvNTeACBGCVelz5+GmnZ5dw=
-github.com/delphix/dct-sdk-go v1.0.0-beta5/go.mod h1:uzV6PTpsNHM24KKvNXaUgIfd5BDbq/fKM+M+PdSZ3JQ=
+github.com/delphix/dct-sdk-go v1.0.0-beta6 h1:QetycQyPNnHsgKmO4vtzpLNVdvqmqBZxcx+cF0ITM7M=
+github.com/delphix/dct-sdk-go v1.0.0-beta6/go.mod h1:uzV6PTpsNHM24KKvNXaUgIfd5BDbq/fKM+M+PdSZ3JQ=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
 v1.0.0-beta5 of the go sdk was missing some files, so upgrading to  v1.0.0-beta6