### PR TITLE
HUBS-1603 Plan phase hangs when VDB resource no longer exists

### DIFF
--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -385,7 +385,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 	client := meta.(*apiClient).client
 	envId := d.Id()
 
-	apiRes, diags := PollForObjectExistence(func() (interface{}, *http.Response, error) {
+	apiRes, diags, _ := PollForObjectExistence(func() (interface{}, *http.Response, error) {
 		return client.EnvironmentsApi.GetEnvironmentById(ctx, envId).Execute()
 	})
 
@@ -426,7 +426,7 @@ func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta
 	if isJobTerminalFailure(job_status) {
 		return diag.Errorf("[NOT OK] Env-Delete %s. JobId: %s / Error: %s", job_status, *apiRes.Job.Id, job_err)
 	}
-	_, diags := PollForObjectDeletion(func() (interface{}, *http.Response, error) {
+	_, diags, _ := PollForObjectDeletion(func() (interface{}, *http.Response, error) {
 		return client.EnvironmentsApi.GetEnvironmentById(ctx, envId).Execute()
 	})
 

--- a/internal/provider/resource_vdb.go
+++ b/internal/provider/resource_vdb.go
@@ -1213,14 +1213,25 @@ func resourceVdbRead(ctx context.Context, d *schema.ResourceData, meta interface
 
 	vdbId := d.Id()
 
-	res, diags := PollForObjectExistence(func() (interface{}, *http.Response, error) {
+	res, diags, statusCode := PollForObjectExistence(func() (interface{}, *http.Response, error) {
 		return client.VDBsApi.GetVdbById(ctx, vdbId).Execute()
 	})
 
 	if diags != nil {
-		ErrorLog.Printf("Error reading the VDB, removing from state.")
-		d.SetId("")
-		return diag.Errorf("[NOT OK] Error in polling vdb")
+		_, diags, _ := PollForObjectDeletion(func() (interface{}, *http.Response, error) {
+			return client.VDBsApi.GetVdbById(ctx, vdbId).Execute()
+		})
+		// This would imply error in poll for deletion so we just log and exit.
+		if diags != nil{
+			ErrorLog.Printf("[NOT OK] Error in polling vdb")
+		}
+		// diags will be nill in case of successful poll for deletion logic aka 404
+		if diags == nil && statusCode==404{
+			ErrorLog.Printf("Error reading the VDB %s, removing from state.",vdbId)
+			d.SetId("")
+		}
+		
+		return nil
 	}
 
 	result, ok := res.(*dctapi.VDB)
@@ -1392,7 +1403,7 @@ func resourceVdbDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diag.Errorf("[NOT OK] VDB-Delete %s. JobId: %s / Error: %s", job_status, *res.Job.Id, job_err)
 	}
 
-	_, diags := PollForObjectDeletion(func() (interface{}, *http.Response, error) {
+	_, diags, _ := PollForObjectDeletion(func() (interface{}, *http.Response, error) {
 		return client.VDBsApi.GetVdbById(ctx, vdbId).Execute()
 	})
 

--- a/internal/provider/utility.go
+++ b/internal/provider/utility.go
@@ -62,18 +62,18 @@ func ResponseBodyToString(body io.ReadCloser) (string, error) {
 	return string(bytes), nil
 }
 
-func PollForObjectExistence(apiCall func() (interface{}, *http.Response, error)) (interface{}, diag.Diagnostics, int) {
+func PollForObjectExistence(apiCall func() (interface{}, *http.Response, error)) (interface{}, diag.Diagnostics) {
 	// Function to check if an object exists in the Delphix estate.
 	return PollForStatusCode(apiCall, http.StatusOK, 10)
 }
 
-func PollForObjectDeletion(apiCall func() (interface{}, *http.Response, error)) (interface{}, diag.Diagnostics, int) {
+func PollForObjectDeletion(apiCall func() (interface{}, *http.Response, error)) (interface{}, diag.Diagnostics) {
 	// Function to check if an object does not exist in the Delphix estate.
 	return PollForStatusCode(apiCall, http.StatusNotFound, 10)
 }
 
 // poll counter is the retry counter for which an api call should be retried.
-func PollForStatusCode(apiCall func() (interface{}, *http.Response, error), statusCode int, maxRetry int) (interface{}, diag.Diagnostics,int) {
+func PollForStatusCode(apiCall func() (interface{}, *http.Response, error), statusCode int, maxRetry int) (interface{}, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var res interface{}
 	var httpRes *http.Response
@@ -81,13 +81,13 @@ func PollForStatusCode(apiCall func() (interface{}, *http.Response, error), stat
 	for i := 0; maxRetry == 0 || i < maxRetry; i++ {
 		if res, httpRes, err = apiCall(); httpRes.StatusCode == statusCode {
 			InfoLog.Printf("[OK] Breaking poll - Status %d reached.", statusCode)
-			return res, nil, httpRes.StatusCode
+			return res, nil
 		}
 		time.Sleep(time.Duration(STATUS_POLL_SLEEP_TIME) * time.Second)
 	}
 	diags = apiErrorResponseHelper(res, httpRes, err)
 	InfoLog.Printf("[NOT OK] Breaking poll - Retry exhausted for status %d", statusCode)
-	return nil, diags, httpRes.StatusCode
+	return nil, diags
 }
 
 func toStringArray(array interface{}) []string {


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
When the VDB was deleted from the engine and terraform plan was being executed, the drift detection mechanism in the provider was not working as expected.Even though the VDB was deleted from the remote the state file reference wasn't getting cleaned up resulting in a hang like behaviour.
# Solution:
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
The drift mechanism was fixed and terraform plan was executing as expected.Also we added extra checks to ensure there is no false override of the state file.
# Testing
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
Tested VDB deletion flow and terraform commands
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
