### PR TITLE
HUBS-1603 Plan phase hangs when VDB resource no longer exists

### DIFF
--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -390,9 +390,16 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if diags != nil {
-		ErrorLog.Printf("Error Env-Read failed for EnvId:%s. Removing from state file.", envId)
-		d.SetId("")
-		return diags
+		_, diags := PollForObjectDeletion(func() (interface{}, *http.Response, error) {
+			return client.EnvironmentsApi.GetEnvironmentById(ctx, envId).Execute()
+		})
+		if diags != nil {
+			ErrorLog.Printf("Error in polling of environment for deletion.")
+		} else {
+			ErrorLog.Printf("Error Env-Read failed for EnvId:%s. Removing from state file.", envId)
+			d.SetId("")
+		}
+		return nil
 	}
 
 	envRes, _ := apiRes.(*dctapi.Environment)


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
When the VDB was deleted from the engine and terraform plan was being executed, the drift detection mechanism in the provider was not working as expected.Even though the VDB was deleted from the remote the state file reference wasn't getting cleaned up resulting in a hang like behaviour.
# Solution:
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
The drift mechanism was fixed and terraform plan was executing as expected.Also we added extra checks to ensure there is no false override of the state file.
# Testing
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
Tested VDB deletion flow and terraform commands
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
