### PR TITLE
HUBS-1603 Plan phase hangs when VDB resource no longer exists

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 env:
-  - PROVIDER_VERSION=1.0.0
+  - PROVIDER_VERSION=1.0.1
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=delphix.com
 NAMESPACE=dct
 NAME=delphix
 BINARY=terraform-provider-${NAME}
-VERSION=1.0.0
+VERSION=1.0.1
 OS_ARCH=darwin_amd64
 
 default: install

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -390,9 +390,16 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 	})
 
 	if diags != nil {
-		ErrorLog.Printf("Error Env-Read failed for EnvId:%s. Removing from state file.", envId)
-		d.SetId("")
-		return diags
+		_, diags := PollForObjectDeletion(func() (interface{}, *http.Response, error) {
+			return client.EnvironmentsApi.GetEnvironmentById(ctx, envId).Execute()
+		})
+		if diags != nil {
+			ErrorLog.Printf("Error in polling of environment for deletion.")
+		} else {
+			ErrorLog.Printf("Error Env-Read failed for EnvId:%s. Removing from state file.", envId)
+			d.SetId("")
+		}
+		return nil
 	}
 
 	envRes, _ := apiRes.(*dctapi.Environment)


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
When the VDB was deleted from the engine and terraform plan was being executed, the drift detection mechanism in the provider was not working as expected.Even though the VDB was deleted from the remote the state file reference wasn't getting cleaned up resulting in a hang like behaviour.
# Solution:
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
The drift mechanism was fixed and terraform plan was executing as expected.Also we added extra checks to ensure there is no false override of the state file.
# Testing
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
Tested VDB deletion flow and terraform commands
`## Creating a VDB using terraform

terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  delphix_vdb.test will be created
  + resource "delphix_vdb" "test" {
      + auto_select_repository = true
      + creation_date          = (known after apply)
      + database_type          = (known after apply)
      + database_version       = (known after apply)
      + engine_id              = (known after apply)
      + environment_id         = (known after apply)
      + fqdn                   = (known after apply)
      + group_name             = (known after apply)
      + id                     = (known after apply)
      + ip_address             = (known after apply)
      + name                   = "test_vdb"
      + parent_id              = (known after apply)
      + provision_type         = "snapshot"
      + source_data_id         = "ORACLE_DB_CONTAINER-1"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
delphix_vdb.test: Creating...
delphix_vdb.test: Still creating... [10s elapsed]
delphix_vdb.test: Still creating... [20s elapsed]
delphix_vdb.test: Still creating... [30s elapsed]
delphix_vdb.test: Still creating... [40s elapsed]
delphix_vdb.test: Still creating... [50s elapsed]
delphix_vdb.test: Still creating... [1m0s elapsed]
delphix_vdb.test: Still creating... [1m10s elapsed]
delphix_vdb.test: Still creating... [1m20s elapsed]
delphix_vdb.test: Still creating... [1m30s elapsed]
delphix_vdb.test: Still creating... [1m40s elapsed]
delphix_vdb.test: Still creating... [1m50s elapsed]
delphix_vdb.test: Still creating... [2m0s elapsed]
delphix_vdb.test: Still creating... [2m10s elapsed]
delphix_vdb.test: Still creating... [2m20s elapsed]
delphix_vdb.test: Still creating... [2m30s elapsed]
delphix_vdb.test: Still creating... [2m40s elapsed]
delphix_vdb.test: Still creating... [2m50s elapsed]
delphix_vdb.test: Still creating... [3m0s elapsed]
delphix_vdb.test: Creation complete after 3m6s [id=1-ORACLE_DB_CONTAINER-3]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.


## Refresh after deletion of VDB from UI:
kishlay.singh@Kishlay-Singhs-MacBook-Pro michelin % terraform refresh
delphix_vdb.test: Refreshing state... [id=1-ORACLE_DB_CONTAINER-3]


## Apply after refresh
kishlay.singh@Kishlay-Singhs-MacBook-Pro michelin % terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

   delphix_vdb.test will be created
  + resource "delphix_vdb" "test" {
      + auto_select_repository = true
      + creation_date          = (known after apply)
      + database_type          = (known after apply)
      + database_version       = (known after apply)
      + engine_id              = (known after apply)
      + environment_id         = (known after apply)
      + fqdn                   = (known after apply)
      + group_name             = (known after apply)
      + id                     = (known after apply)
      + ip_address             = (known after apply)
      + name                   = "test_vdb"
      + parent_id              = (known after apply)
      + provision_type         = "snapshot"
      + source_data_id         = "ORACLE_DB_CONTAINER-1"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
delphix_vdb.test: Creating...
delphix_vdb.test: Still creating... [10s elapsed]
delphix_vdb.test: Still creating... [20s elapsed]
delphix_vdb.test: Still creating... [30s elapsed]
delphix_vdb.test: Still creating... [40s elapsed]
delphix_vdb.test: Still creating... [50s elapsed]
delphix_vdb.test: Still creating... [1m0s elapsed]
delphix_vdb.test: Still creating... [1m10s elapsed]
delphix_vdb.test: Still creating... [1m20s elapsed]
delphix_vdb.test: Still creating... [1m30s elapsed]
delphix_vdb.test: Still creating... [1m40s elapsed]
delphix_vdb.test: Still creating... [1m50s elapsed]
delphix_vdb.test: Still creating... [2m0s elapsed]
delphix_vdb.test: Still creating... [2m10s elapsed]
delphix_vdb.test: Still creating... [2m20s elapsed]
delphix_vdb.test: Still creating... [2m30s elapsed]
delphix_vdb.test: Creation complete after 2m34s [id=1-ORACLE_DB_CONTAINER-4]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.a`
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
