### PR TITLE
HUBS-1692 | Additional params support for provision

### DIFF
--- a/docs/resources/vdb.md
+++ b/docs/resources/vdb.md
@@ -223,6 +223,42 @@ Environment variable to be set when the engine creates a VDB. See the Engine doc
   * `key` - (Required) Key of the tag
   * `value` - (Required) Value of the tag
 
+* `make_current_account_owner` - (Optional) Whether the account provisioning this VDB must be configured as owner of the VDB. 
+
+* `config_params` - (Optional) Database configuration parameter overrides
+
+* `appdata_source_params` - The JSON payload conforming to the DraftV4 schema based on the type of application data being manipulated.
+
+* `appdata_config_params` - (Optional) The list of parameters specified by the source config schema in the toolkit
+
+* `additional_mount_points` - (Optional) Specifies additional locations on which to mount a subdirectory of an AppData container
+  * `shared_path` - (Required) Relative path within the container of the directory that should be mounted.
+  * `mount_path` - (Required) Absolute path on the target environment were the filesystem should be mounted
+  * `environment_id` - (Required) The entity ID of the environment on which the file system will be mounted.
+
+* `vcdb_tde_key_identifier` - (Optional) ID of the key created by Delphix. (Oracle Multitenant Only)
+
+* `cdb_tde_keystore_password` - (Optional) The password for the Transparent Data Encryption keystore associated with the CDB. (Oracle Multitenant Only)
+
+* `target_vcdb_tde_keystore_path` - (Optional) Path to the keystore of the target vCDB. (Oracle Multitenant Only)
+
+* `tde_key_identifier` - (Optional) ID of the key created by Delphix. (Oracle Multitenant Only)
+
+* `tde_exported_key_file_secret` - (Optional) Secret to be used while exporting and importing vPDB encryption keys if Transparent Data Encryption is enabled on the vPDB. (Oracle Multitenant Only)
+
+* `parent_tde_keystore_password` - (Optional) The password of the keystore specified in parentTdeKeystorePath. (Oracle Multitenant Only)
+
+* `parent_tde_keystore_path` - (Optional) Path to a copy of the parent's Oracle transparent data encryption keystore on the target host. Required to provision from snapshots containing encrypted database files. (Oracle Multitenant Only)
+
+* `oracle_rac_custom_env_vars` - (Optional) Environment variable to be set when the engine creates an Oracle RAC VDB. See the Engine documentation for the list of allowed/denied environment variables and rules about substitution.
+  * `node_id` - (Required) The node id of the cluster.
+  * `name` - (Required) Name of the environment variable
+  * `value` - (Required) Value of the environment variable.
+
+* `oracle_rac_custom_env_files` - (Optional) Environment files to be sourced when the Engine creates an Oracle RAC VDB. This path can be followed by parameters. Paths and parameters are separated by spaces.
+  * `node_id` - (Required) The node id of the cluster.
+  * `path_parameters` - (Required) This references a file from which certain parameters will be loaded.
+
 
 ## Attribute Reference
 

--- a/internal/provider/resource_vdb.go
+++ b/internal/provider/resource_vdb.go
@@ -575,6 +575,100 @@ func resourceVdb() *schema.Resource {
 			"appdata_config_params": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
+			},
+			"make_current_account_owner": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"config_params": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"additional_mount_points": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"shared_path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"mount_path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"environment_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"vcdb_tde_key_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cdb_tde_keystore_password": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"target_vcdb_tde_keystore_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tde_key_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tde_exported_key_file_secret": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parent_tde_keystore_password": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parent_tde_keystore_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"oracle_rac_custom_env_vars": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"oracle_rac_custom_env_files": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"path_parameters": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -605,6 +699,47 @@ func toTagArray(array interface{}) []dctapi.Tag {
 		tag_item := dctapi.NewTag(item_map["key"].(string), item_map["value"].(string))
 
 		items = append(items, *tag_item)
+	}
+	return items
+}
+
+func toAdditionalMountPointsArray(array interface{}) []dctapi.AdditionalMountPoint {
+	items := []dctapi.AdditionalMountPoint{}
+	for _, item := range array.([]interface{}) {
+		item_map := item.(map[string]interface{})
+		addMntPts := dctapi.NewAdditionalMountPoint()
+		addMntPts.SetEnvironmentId(item_map["environment_id"].(string))
+		addMntPts.SetMountPath(item_map["mount_path"].(string))
+		addMntPts.SetSharedPath(item_map["shared_path"].(string))
+
+		items = append(items, *addMntPts)
+	}
+	return items
+}
+
+func toOracleRacCustomEnvVars(array interface{}) []dctapi.OracleRacCustomEnvVar {
+	items := []dctapi.OracleRacCustomEnvVar{}
+	for _, item := range array.([]interface{}) {
+		item_map := item.(map[string]interface{})
+		oracleRacCustomEnvVars := dctapi.NewOracleRacCustomEnvVar()
+		oracleRacCustomEnvVars.SetName(item_map["name"].(string))
+		oracleRacCustomEnvVars.SetNodeId(item_map["node_id"].(string))
+		oracleRacCustomEnvVars.SetValue(item_map["value"].(string))
+
+		items = append(items, *oracleRacCustomEnvVars)
+	}
+	return items
+}
+
+func toOracleRacCustomEnvFiles(array interface{}) []dctapi.OracleRacCustomEnvFile {
+	items := []dctapi.OracleRacCustomEnvFile{}
+	for _, item := range array.([]interface{}) {
+		item_map := item.(map[string]interface{})
+		oracleRacCustomEnvFiles := dctapi.NewOracleRacCustomEnvFile()
+		oracleRacCustomEnvFiles.SetNodeId(item_map["node_id"].(string))
+		oracleRacCustomEnvFiles.SetPathParameters(item_map["path_parameters"].(string))
+
+		items = append(items, *oracleRacCustomEnvFiles)
 	}
 	return items
 }
@@ -784,6 +919,44 @@ func helper_provision_by_snapshot(ctx context.Context, d *schema.ResourceData, m
 		appdata_config_params := make(map[string]interface{})
 		json.Unmarshal([]byte(v.(string)), &appdata_config_params)
 		provisionVDBBySnapshotParameters.SetAppdataConfigParams(appdata_config_params)
+	}
+	if v, has_v := d.GetOk("config_params"); has_v {
+		config_params := make(map[string]interface{})
+		json.Unmarshal([]byte(v.(string)), &config_params)
+		provisionVDBBySnapshotParameters.SetConfigParams(config_params)
+	}
+	if v, has_v := d.GetOk("make_current_account_owner"); has_v {
+		provisionVDBBySnapshotParameters.SetMakeCurrentAccountOwner(v.(bool))
+	}
+	if v, has_v := d.GetOk("vcdb_tde_key_identifier"); has_v {
+		provisionVDBBySnapshotParameters.SetVcdbTdeKeyIdentifier(v.(string))
+	}
+	if v, has_v := d.GetOk("cdb_tde_keystore_password"); has_v {
+		provisionVDBBySnapshotParameters.SetCdbTdeKeystorePassword(v.(string))
+	}
+	if v, has_v := d.GetOk("target_vcdb_tde_keystore_path"); has_v {
+		provisionVDBBySnapshotParameters.SetTargetVcdbTdeKeystorePath(v.(string))
+	}
+	if v, has_v := d.GetOk("tde_key_identifier"); has_v {
+		provisionVDBBySnapshotParameters.SetTdeKeyIdentifier(v.(string))
+	}
+	if v, has_v := d.GetOk("tde_exported_key_file_secret"); has_v {
+		provisionVDBBySnapshotParameters.SetTdeExportedKeyFileSecret(v.(string))
+	}
+	if v, has_v := d.GetOk("parent_tde_keystore_password"); has_v {
+		provisionVDBBySnapshotParameters.SetParentTdeKeystorePassword(v.(string))
+	}
+	if v, has_v := d.GetOk("parent_tde_keystore_path"); has_v {
+		provisionVDBBySnapshotParameters.SetParentTdeKeystorePath(v.(string))
+	}
+	if v, has_v := d.GetOk("additional_mount_points"); has_v {
+		provisionVDBBySnapshotParameters.SetAdditionalMountPoints(toAdditionalMountPointsArray(v))
+	}
+	if v, has_v := d.GetOk("oracle_rac_custom_env_files"); has_v {
+		provisionVDBBySnapshotParameters.SetOracleRacCustomEnvFiles(toOracleRacCustomEnvFiles(v))
+	}
+	if v, has_v := d.GetOk("oracle_rac_custom_env_vars"); has_v {
+		provisionVDBBySnapshotParameters.SetOracleRacCustomEnvVars(toOracleRacCustomEnvVars(v))
 	}
 
 	req := client.VDBsApi.ProvisionVdbBySnapshot(ctx)
@@ -992,6 +1165,44 @@ func helper_provision_by_timestamp(ctx context.Context, d *schema.ResourceData, 
 		json.Unmarshal([]byte(v.(string)), &appdata_config_params)
 		provisionVDBByTimestampParameters.SetAppdataConfigParams(appdata_config_params)
 	}
+	if v, has_v := d.GetOk("config_params"); has_v {
+		config_params := make(map[string]interface{})
+		json.Unmarshal([]byte(v.(string)), &config_params)
+		provisionVDBByTimestampParameters.SetConfigParams(config_params)
+	}
+	if v, has_v := d.GetOk("make_current_account_owner"); has_v {
+		provisionVDBByTimestampParameters.SetMakeCurrentAccountOwner(v.(bool))
+	}
+	if v, has_v := d.GetOk("vcdb_tde_key_identifier"); has_v {
+		provisionVDBByTimestampParameters.SetVcdbTdeKeyIdentifier(v.(string))
+	}
+	if v, has_v := d.GetOk("cdb_tde_keystore_password"); has_v {
+		provisionVDBByTimestampParameters.SetCdbTdeKeystorePassword(v.(string))
+	}
+	if v, has_v := d.GetOk("target_vcdb_tde_keystore_path"); has_v {
+		provisionVDBByTimestampParameters.SetTargetVcdbTdeKeystorePath(v.(string))
+	}
+	if v, has_v := d.GetOk("tde_key_identifier"); has_v {
+		provisionVDBByTimestampParameters.SetTdeKeyIdentifier(v.(string))
+	}
+	if v, has_v := d.GetOk("tde_exported_key_file_secret"); has_v {
+		provisionVDBByTimestampParameters.SetTdeExportedKeyFileSecret(v.(string))
+	}
+	if v, has_v := d.GetOk("parent_tde_keystore_password"); has_v {
+		provisionVDBByTimestampParameters.SetParentTdeKeystorePassword(v.(string))
+	}
+	if v, has_v := d.GetOk("parent_tde_keystore_path"); has_v {
+		provisionVDBByTimestampParameters.SetParentTdeKeystorePath(v.(string))
+	}
+	if v, has_v := d.GetOk("additional_mount_points"); has_v {
+		provisionVDBByTimestampParameters.SetAdditionalMountPoints(toAdditionalMountPointsArray(v))
+	}
+	if v, has_v := d.GetOk("oracle_rac_custom_env_files"); has_v {
+		provisionVDBByTimestampParameters.SetOracleRacCustomEnvFiles(toOracleRacCustomEnvFiles(v))
+	}
+	if v, has_v := d.GetOk("oracle_rac_custom_env_vars"); has_v {
+		provisionVDBByTimestampParameters.SetOracleRacCustomEnvVars(toOracleRacCustomEnvVars(v))
+	}
 
 	req := client.VDBsApi.ProvisionVdbByTimestamp(ctx)
 
@@ -1184,6 +1395,44 @@ func helper_provision_by_bookmark(ctx context.Context, d *schema.ResourceData, m
 		json.Unmarshal([]byte(v.(string)), &appdata_config_params)
 		provisionVDBFromBookmarkParameters.SetAppdataConfigParams(appdata_config_params)
 	}
+	if v, has_v := d.GetOk("config_params"); has_v {
+		config_params := make(map[string]interface{})
+		json.Unmarshal([]byte(v.(string)), &config_params)
+		provisionVDBFromBookmarkParameters.SetConfigParams(config_params)
+	}
+	if v, has_v := d.GetOk("make_current_account_owner"); has_v {
+		provisionVDBFromBookmarkParameters.SetMakeCurrentAccountOwner(v.(bool))
+	}
+	if v, has_v := d.GetOk("vcdb_tde_key_identifier"); has_v {
+		provisionVDBFromBookmarkParameters.SetVcdbTdeKeyIdentifier(v.(string))
+	}
+	if v, has_v := d.GetOk("cdb_tde_keystore_password"); has_v {
+		provisionVDBFromBookmarkParameters.SetCdbTdeKeystorePassword(v.(string))
+	}
+	if v, has_v := d.GetOk("target_vcdb_tde_keystore_path"); has_v {
+		provisionVDBFromBookmarkParameters.SetTargetVcdbTdeKeystorePath(v.(string))
+	}
+	if v, has_v := d.GetOk("tde_key_identifier"); has_v {
+		provisionVDBFromBookmarkParameters.SetTdeKeyIdentifier(v.(string))
+	}
+	if v, has_v := d.GetOk("tde_exported_key_file_secret"); has_v {
+		provisionVDBFromBookmarkParameters.SetTdeExportedKeyFileSecret(v.(string))
+	}
+	if v, has_v := d.GetOk("parent_tde_keystore_password"); has_v {
+		provisionVDBFromBookmarkParameters.SetParentTdeKeystorePassword(v.(string))
+	}
+	if v, has_v := d.GetOk("parent_tde_keystore_path"); has_v {
+		provisionVDBFromBookmarkParameters.SetParentTdeKeystorePath(v.(string))
+	}
+	if v, has_v := d.GetOk("additional_mount_points"); has_v {
+		provisionVDBFromBookmarkParameters.SetAdditionalMountPoints(toAdditionalMountPointsArray(v))
+	}
+	if v, has_v := d.GetOk("oracle_rac_custom_env_files"); has_v {
+		provisionVDBFromBookmarkParameters.SetOracleRacCustomEnvFiles(toOracleRacCustomEnvFiles(v))
+	}
+	if v, has_v := d.GetOk("oracle_rac_custom_env_vars"); has_v {
+		provisionVDBFromBookmarkParameters.SetOracleRacCustomEnvVars(toOracleRacCustomEnvVars(v))
+	}
 
 	req := client.VDBsApi.ProvisionVdbFromBookmark(ctx)
 
@@ -1287,8 +1536,15 @@ func resourceVdbRead(ctx context.Context, d *schema.ResourceData, meta interface
 	d.Set("parent_id", result.GetParentId())
 	d.Set("group_name", result.GetGroupName())
 	d.Set("creation_date", result.GetCreationDate().String())
-	d.Set("appdata_source_params", result.GetAppdataSourceParams())
-	d.Set("appdata_config_params", result.GetAppdataConfigParams())
+
+	appdata_source_params, _ := json.Marshal(result.GetAppdataSourceParams())
+	d.Set("appdata_source_params", string(appdata_source_params))
+	appdata_config_params, _ := json.Marshal(result.GetAppdataConfigParams())
+	d.Set("appdata_config_params", string(appdata_config_params))
+	config_params, _ := json.Marshal(result.GetConfigParams())
+	d.Set("config_params", string(config_params))
+	d.Set("additional_mount_points", flattenAdditionalMountPoints(result.GetAdditionalMountPoints()))
+
 	d.Set("id", vdbId)
 
 	return diags
@@ -1395,6 +1651,39 @@ func resourceVdbUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	if d.HasChange("cdc_on_provision") {
 		updateVDBParam.SetCdcOnProvision(d.Get("cdc_on_provision").(bool))
+	}
+	if d.HasChange("additional_mount_points") {
+		updateVDBParam.SetAdditionalMountPoints(toAdditionalMountPointsArray(d.Get("additional_mount_points")))
+	}
+	if d.HasChange("parent_tde_keystore_path") {
+		updateVDBParam.SetParentTdeKeystorePath(d.Get("parent_tde_keystore_path").(string))
+	}
+	if d.HasChange("parent_tde_keystore_password") {
+		updateVDBParam.SetParentTdeKeystorePassword(d.Get("parent_tde_keystore_password").(string))
+	}
+	if d.HasChange("tde_key_identifier") {
+		updateVDBParam.SetTdeKeyIdentifier(d.Get("tde_key_identifier").(string))
+	}
+	if d.HasChange("target_vcdb_tde_keystore_path") {
+		updateVDBParam.SetTargetVcdbTdeKeystorePath(d.Get("target_vcdb_tde_keystore_path").(string))
+	}
+	if d.HasChange("cdb_tde_keystore_password") {
+		updateVDBParam.SetCdbTdeKeystorePassword(d.Get("cdb_tde_keystore_password").(string))
+	}
+	if d.HasChange("appdata_source_params") {
+		appdata_source_params := make(map[string]interface{})
+		json.Unmarshal([]byte(d.Get("appdata_source_params").(string)), &appdata_source_params)
+		updateVDBParam.SetAppdataSourceParams(appdata_source_params)
+	}
+	if d.HasChange("appdata_config_params") {
+		appdata_config_params := make(map[string]interface{})
+		json.Unmarshal([]byte(d.Get("appdata_config_params").(string)), &appdata_config_params)
+		updateVDBParam.SetAppdataConfigParams(appdata_config_params)
+	}
+	if d.HasChange("config_params") {
+		config_params := make(map[string]interface{})
+		json.Unmarshal([]byte(d.Get("config_params").(string)), &config_params)
+		updateVDBParam.SetConfigParams(config_params)
 	}
 
 	res, httpRes, err := client.VDBsApi.UpdateVdbById(ctx, d.Get("id").(string)).UpdateVDBParameters(*updateVDBParam).Execute()

--- a/internal/provider/utility.go
+++ b/internal/provider/utility.go
@@ -114,6 +114,21 @@ func flattenHosts(hosts []dctapi.Host) []interface{} {
 	return make([]interface{}, 0)
 }
 
+func flattenAdditionalMountPoints(additional_mount_points []dctapi.AdditionalMountPoint) []interface{} {
+	if additional_mount_points != nil {
+		returned_additional_mount_points := make([]interface{}, len(additional_mount_points))
+		for i, additional_mount_point := range additional_mount_points {
+			returned_additional_mount_point := make(map[string]interface{})
+			returned_additional_mount_point["shared_path"] = additional_mount_point.GetSharedPath()
+			returned_additional_mount_point["mount_path"] = additional_mount_point.GetMountPath()
+			returned_additional_mount_point["environment_id"] = additional_mount_point.GetEnvironmentId()
+			returned_additional_mount_points[i] = returned_additional_mount_point
+		}
+		return returned_additional_mount_points
+	}
+	return make([]interface{}, 0)
+}
+
 func apiErrorResponseHelper(res interface{}, httpRes *http.Response, err error) diag.Diagnostics {
 	// Helper function to return Diagnostics object if there is
 	// a failure during API call.


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
There are some newly added params for RAC and Multi Tenant TDE oracle vdb provisioning that we didnt support yet.
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
# Solution:
Added support for the below params:
`make_current_account_owner
config_params
additional_mount_points
vcdb_tde_key_identifier
cdb_tde_keystore_password
target_vcdb_tde_keystore_path
tde_key_identifier
tde_exported_key_file_secret
parent_tde_keystore_password
parentTdeKeystorePath
oracle_rac_custom_env_vars
oracle_rac_custom_env_files`
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
# Testing
These tests are also properly documented in the respective JIRA for it. i.e, https://delphix.atlassian.net/browse/HUBS-1694
below is the list of validation along with the tf file configured:
Additional mount point update
tf: `variable "tags_var" {
  type = set(object({
    key            = string
    value         = string
  }))

  default = [
    {
      "key": "string",
      "value": "string",
    },
    {
      "key": "string1",
      "value": "string1",
    }
  ]
}

resource "delphix_vdb" "test_postgres_tf" {
  auto_select_repository = true
  source_data_id        = "4-APPDATA_CONTAINER-21"
  name                  = "test_postgres_tf2"

  dynamic "tags" {
    for_each = var.tags_var
    content{
      key            = tags.value.key
      value          = tags.value.value
    }
  }

  appdata_source_params = jsonencode({
    mountLocation       = "/mnt/GAT"
    postgresPort        = 5434
    configSettingsStg   = [{ propertyName: "timezone", value:"GMT", commentProperty:false}]
    })

  additional_mount_points {
    shared_path       = "/"
    mount_path        = "/work"
    environment_id    = "4-UNIX_HOST_ENVIRONMENT-14"
  }
}`

console:
`uddipaan.hazarika@Uddipaan-Hazarikas-MacBook-Pro snapshot % terraform apply --auto-approve 
delphix_vdb.test_postgres_tf: Refreshing state... [id=4-APPDATA_CONTAINER-25]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # delphix_vdb.test_postgres_tf will be updated in-place
  ~ resource "delphix_vdb" "test_postgres_tf" {
        id                     = "4-APPDATA_CONTAINER-25"
        name                   = "test_postgres_tf2"
        # (12 unchanged attributes hidden)

      + additional_mount_points {
          + environment_id = "4-UNIX_HOST_ENVIRONMENT-14"
          + mount_path     = "/work"
          + shared_path    = "/"
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
delphix_vdb.test_postgres_tf: Modifying... [id=4-APPDATA_CONTAINER-25]
delphix_vdb.test_postgres_tf: Still modifying... [id=4-APPDATA_CONTAINER-25, 10s elapsed]
delphix_vdb.test_postgres_tf: Modifications complete after 14s [id=4-APPDATA_CONTAINER-25]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.`

appdata_config_param update:
tf:
'resource "delphix_vdb" "test_postgres_tf" {
  auto_select_repository = true
  source_data_id        = "4-APPDATA_CONTAINER-21"
  name                  = "test_postgres_tf3"

  dynamic "tags" {
    for_each = var.tags_var
    content{
      key            = tags.value.key
      value          = tags.value.value
    }
  }

  appdata_source_params = jsonencode({
    mountLocation       = "/mnt/GAT"
    postgresPort        = 5434
    configSettingsStg   = [{ propertyName: "timezone", value:"GMT", commentProperty:false}]
    })

  appdata_config_params = jsonencode({
    name = "Postgres-5434 - /mnt/GAT/data2"
  })}'

console:
`uddipaan.hazarika@Uddipaan-Hazarikas-MacBook-Pro snapshot % terraform apply --auto-approve
delphix_vdb.test_postgres_tf: Refreshing state... [id=4-APPDATA_CONTAINER-47]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # delphix_vdb.test_postgres_tf will be updated in-place
  ~ resource "delphix_vdb" "test_postgres_tf" {
      ~ appdata_config_params  = jsonencode(
          ~ {
              ~ name = "Postgres-5434 - /mnt/GAT/data" -> "Postgres-5434 - /mnt/GAT/data2"
            }
        )
        id                     = "4-APPDATA_CONTAINER-47"
        name                   = "test_postgres_tf3"
        # (13 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
delphix_vdb.test_postgres_tf: Modifying... [id=4-APPDATA_CONTAINER-47]
delphix_vdb.test_postgres_tf: Still modifying... [id=4-APPDATA_CONTAINER-47, 10s elapsed]
delphix_vdb.test_postgres_tf: Still modifying... [id=4-APPDATA_CONTAINER-47, 20s elapsed]
delphix_vdb.test_postgres_tf: Still modifying... [id=4-APPDATA_CONTAINER-47, 30s elapsed]
delphix_vdb.test_postgres_tf: Modifications complete after 31s [id=4-APPDATA_CONTAINER-47]`

Config_params:
tf:
`variable "tags_var" {
  type = set(object({
    key            = string
    value         = string
  }))

  default = [
    {
      "key": "string",
      "value": "string",
    },
    {
      "key": "string1",
      "value": "string1",
    }
  ]
}

resource "delphix_vdb" "test_postgres_tf" {
  auto_select_repository = true
  source_data_id        = "4-APPDATA_CONTAINER-21"
  name                  = "test_postgres_tf3"

  dynamic "tags" {
    for_each = var.tags_var
    content{
      key            = tags.value.key
      value          = tags.value.value
    }
  }

  appdata_source_params = jsonencode({
    mountLocation       = "/mnt/GAT"
    postgresPort        = 5434
    configSettingsStg   = [{ propertyName: "timezone", value:"GMT", commentProperty:false}]
    })

  appdata_config_params = jsonencode({
    name = "Postgres-5434 - /mnt/GAT/data2"
  })

  config_params = jsonencode({
    processes = 150
  })} `

console:
`uddipaan.hazarika@Uddipaan-Hazarikas-MacBook-Pro snapshot % terraform apply --auto-approve 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # delphix_vdb.test_postgres_tf will be created
  + resource "delphix_vdb" "test_postgres_tf" {
      + appdata_config_params  = jsonencode(
            {
              + name = "Postgres-5434 - /mnt/GAT/data2"
            }
        )
      + appdata_source_params  = jsonencode(
            {
              + configSettingsStg = [
                  + {
                      + commentProperty = false
                      + propertyName    = "timezone"
                      + value           = "GMT"
                    },
                ]
              + mountLocation     = "/mnt/GAT"
              + postgresPort      = 5434
            }
        )
      + auto_select_repository = true
      + config_params          = jsonencode(
            {
              + processes = 150
            }
        )
      + creation_date          = (known after apply)
      + database_type          = (known after apply)
      + database_version       = (known after apply)
      + engine_id              = (known after apply)
      + environment_id         = (known after apply)
      + fqdn                   = (known after apply)
      + group_name             = (known after apply)
      + id                     = (known after apply)
      + ip_address             = (known after apply)
      + name                   = "test_postgres_tf3"
      + parent_id              = (known after apply)
      + provision_type         = "snapshot"
      + source_data_id         = "4-APPDATA_CONTAINER-21"

      + tags {
          + key   = "string"
          + value = "string"
        }
      + tags {
          + key   = "string1"
          + value = "string1"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
delphix_vdb.test_postgres_tf: Creating...
delphix_vdb.test_postgres_tf: Still creating... [10s elapsed]
delphix_vdb.test_postgres_tf: Still creating... [20s elapsed]
delphix_vdb.test_postgres_tf: Creation complete after 27s [id=4-APPDATA_CONTAINER-48]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.`


Update config params:
tf:
`uddipaan.hazarika@Uddipaan-Hazarikas-MacBook-Pro snapshot % terraform apply --auto-approve 
delphix_vdb.test_postgres_tf: Refreshing state... [id=4-APPDATA_CONTAINER-48]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # delphix_vdb.test_postgres_tf will be updated in-place
  ~ resource "delphix_vdb" "test_postgres_tf" {
      ~ appdata_config_params  = jsonencode(
          ~ {
              ~ name = "Postgres-5434 - /mnt/GAT/data" -> "Postgres-5434 - /mnt/GAT/data2"
            }
        )
      ~ config_params          = jsonencode(
          ~ null -> {
              + processes = 151
            }
        )
        id                     = "4-APPDATA_CONTAINER-48"
        name                   = "test_postgres_tf3"
        # (12 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
delphix_vdb.test_postgres_tf: Modifying... [id=4-APPDATA_CONTAINER-48]
delphix_vdb.test_postgres_tf: Still modifying... [id=4-APPDATA_CONTAINER-48, 10s elapsed]
delphix_vdb.test_postgres_tf: Modifications complete after 20s [id=4-APPDATA_CONTAINER-48]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.`

TDE Params: (just validating the DCT api request payload)
tf:
`resource "delphix_vdb" "vdb_name" {
  provision_type         = "snapshot"
  auto_select_repository = true
  source_data_id         = "6-ORACLE_DB_CONTAINER-2" //4-ORACLE_DB_CONTAINER-27

  pre_refresh {
    name    = "n"
    command = "time"
    shell   = "bash"
  }

  vcdb_name                         = "my_vcdb" //(MT)
  vcdb_database_name                = "VCCD_6QQ" //(MT)
  target_vcdb_tde_keystore_path     = "/foo/cdb/tde" //(MT)
  parent_tde_keystore_password      = "delphix" //(MT)
  cdb_tde_keystore_password         = "delphix" //(MT)
  tde_key_identifier                = "inbakooufdfekobwawxmwdgmjjypmjinvbc" //(MT)
  vcdb_tde_key_identifier           = "inbakooufdfekobwawxmwdgmjjypmjinpoc" //(MT)
  parent_tde_keystore_path          = "/foo/bar/tde" //(MT)
  tde_exported_key_file_secret      = "delphix" //(MT)
}`

Payload:
`POST /v3/vdbs/provision_by_snapshot HTTP/1.1
Host: dct.dlpxdc.co
User-Agent: Terraform/1.3.9 (+https://www.terraform.io/) Terraform-Plugin-SDK/2.10.1 terraform-provider-delphix/dev
Content-Length: 553
Accept: application/json
Authorization: apk 1.wYP5M7oC8yVFrgGMCWmMidsoPqLULH3fCVghpdlr95pP203pqgLO3EM6hAOQSf4V
Content-Type: application/json
X-Dct-Client-Name: Terraform
Accept-Encoding: gzip

{"auto_select_repository":true,"cdb_tde_keystore_password":"delphix","make_current_account_owner":true,"parentTdeKeystorePath":"/foo/bar/tde","parent_tde_keystore_password":"delphix","pre_refresh":[{"command":"time","name":"n","shell":"bash"}],"source_data_id":"6-ORACLE_DB_CONTAINER-2","target_vcdb_tde_keystore_path":"/foo/cdb/tde","tde_exported_key_file_secret":"delphix","tde_key_identifier":"inbakooufdfekobwawxmwdgmjjypmjinvbc","vcdb_database_name":"VCCD_6QQ","vcdb_name":"my_vcdb","vcdb_tde_key_identifier":"inbakooufdfekobwawxmwdgmjjypmjinpoc"}`

RAC PARAMS:
tf:
`resource "delphix_vdb" "vdb_name" {
  provision_type         = "snapshot"
  auto_select_repository = true
  source_data_id         = "4-ORACLE_DB_CONTAINER-51" //4-ORACLE_DB_CONTAINER-27

  pre_refresh {
    name    = "n"
    command = "time"
    shell   = "bash"
  }

  oracle_rac_custom_env_vars {
    node_id = "ORACLE_CLUSTER_NODE-3"
    name = "name"
    value = "value"
  }
  oracle_rac_custom_env_files {
    node_id = "ORACLE_CLUSTER_NODE-3"
    path_parameters = "mnt/provision"
  }
}`

Payload:
`{"auto_select_repository":true,"make_current_account_owner":true,"oracle_rac_custom_env_files":[{"node_id":"ORACLE_CLUSTER_NODE-3","path_parameters":"mnt/provision"}],"oracle_rac_custom_env_vars":[{"name":"name","node_id":"ORACLE_CLUSTER_NODE-3","value":"value"}],"pre_refresh":[{"command":"time","name":"n","shell":"bash"}],"source_data_id":"4-ORACLE_DB_CONTAINER-51"}`


make_current_owner: 
`uddipaan.hazarika@Uddipaan-Hazarikas-MacBook-Pro snapshot % terraform apply --auto-approve 

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:

create

Terraform will perform the following actions:

delphix_vdb.test_postgres_tf will be created

resource "delphix_vdb" "test_postgres_tf" {

appdata_config_params      = jsonencode(    {      + name = "Postgres-5434 - /mnt/GAT/data2"    })

appdata_source_params      = jsonencode(    {      + configSettingsStg = [          + {              + commentProperty = false              + propertyName    = "timezone"              + value           = "GMT"            },        ]      + mountLocation     = "/mnt/GAT"      + postgresPort      = 5434    })

auto_select_repository     = true

config_params              = jsonencode(    {      + processes = 151    })

creation_date              = (known after apply)

database_type              = (known after apply)

database_version           = (known after apply)

engine_id                  = (known after apply)

environment_id             = (known after apply)

fqdn                       = (known after apply)

group_name                 = (known after apply)

id                         = (known after apply)

ip_address                 = (known after apply)

make_current_account_owner = true

name                       = "test_postgres_tf3"

parent_id                  = (known after apply)

provision_type             = "snapshot"

source_data_id             = "4-APPDATA_CONTAINER-21"

tags {

key   = "string"

value = "string"}

tags {

key   = "string1"

value = "string1"}}

Plan: 1 to add, 0 to change, 0 to destroy.
delphix_vdb.test_postgres_tf: Creating...
delphix_vdb.test_postgres_tf: Still creating... [10s elapsed]
delphix_vdb.test_postgres_tf: Still creating... [20s elapsed]
delphix_vdb.test_postgres_tf: Still creating... [30s elapsed]
delphix_vdb.test_postgres_tf: Still creating... [40s elapsed]
delphix_vdb.test_postgres_tf: Creation complete after 46s [id=4-APPDATA_CONTAINER-49]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
uddipaan.hazarika@Uddipaan-Hazarikas-MacBook-Pro snapshot % terraform apply --auto-approve
delphix_vdb.test_postgres_tf: Refreshing state... [id=4-APPDATA_CONTAINER-49]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

delphix_vdb.test_postgres_tf will be updated in-place

  ~ resource "delphix_vdb" "test_postgres_tf" {
      ~ appdata_config_params      = jsonencode(
          ~ {
              ~ name = "Postgres-5434 - /mnt/GAT/data" -> "Postgres-5434 - /mnt/GAT/data2"
            }
        )
      ~ config_params              = jsonencode(
          ~ null -> {
              + processes = 151
            }
        )
        id                         = "4-APPDATA_CONTAINER-49"
      ~ make_current_account_owner = true -> false
        name                       = "test_postgres_tf3"
        # (12 unchanged attributes hidden)

    # (2 unchanged blocks hidden)
}

Plan: 0 to add, 1 to change, 0 to destroy.
delphix_vdb.test_postgres_tf: Modifying... [id=4-APPDATA_CONTAINER-49]
delphix_vdb.test_postgres_tf: Still modifying... [id=4-APPDATA_CONTAINER-49, 10s elapsed]
delphix_vdb.test_postgres_tf: Modifications complete after 19s [id=4-APPDATA_CONTAINER-49]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.`

<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
