### PR TITLE
HUBS-1709 | cluster_node_ids wrong schema type

### DIFF
--- a/internal/provider/resource_vdb.go
+++ b/internal/provider/resource_vdb.go
@@ -96,8 +96,11 @@ func resourceVdb() *schema.Resource {
 				Optional: true,
 			},
 			"cluster_node_ids": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeList,
 				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 			"truncate_log_on_checkpoint": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
# Context: 
The parameter for cluster_node_ids was configured with a wrong schema type. More Info: https://delphix.atlassian.net/browse/HUBS-1709
<!--
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem: 
cluster_node_ids parameter defined as a string whereas DCT takes it as a list of string.
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
# Solution: 
Conform the type of the param to conform to DCT request type(list of string)
`  "cluster_node_ids": [
    "ORACLE_CLUSTER_NODE-1"
  ],`
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
# Testing:
Payload:

```
resource "delphix_vdb" "vdb_name" {
  provision_type         = "snapshot"
  auto_select_repository = true
  source_data_id         = "9-ORACLE_DB_CONTAINER-51" //4-ORACLE_DB_CONTAINER-27

  cluster_node_ids = ["ORACLE_CLUSTER_NODE-3"]
}
```
Result:(Log Level = TRACE)

```
REQUEST: {"auto_select_repository":true,"cluster_node_ids":["ORACLE_CLUSTER_NODE-3"],"make_current_account_owner":true,"source_data_id":"9-ORACLE_DB_CONTAINER-51"}
RESPONSE: {"job":{"id":"d24b87a062924001ba8ffc7c106d4dc6","status":"STARTED","type":"VDB_PROVISION","target_id":"9-ORACLE_DB_CONTAINER-87","start_time":"2023-05-18T16:46:03.466348Z"},"vdb_id":"9-ORACLE_DB_CONTAINER-87"}
```
PS: for some oracle rac mumbo jumbo, the provision failed but it atleast started the provision process in the UI. 


_Error: [NOT OK] Job d24b87a062924001ba8ffc7c106d4dc6 FAILED with error Failed to mount database instance. See command output for more information._
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
