### PR TITLE
HUBS-1815 | Terraform - VDB update call fails when appdata_source_params are absent

### DIFF
--- a/internal/provider/resource_vdb.go
+++ b/internal/provider/resource_vdb.go
@@ -574,6 +574,7 @@ func resourceVdb() *schema.Resource {
 			"appdata_source_params": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"appdata_config_params": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
# Context:
Terraform - VDB update call fails when appdata_source_params are absent.
https://delphix.atlassian.net/browse/HUBS-1815
<!--
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
We were not specifying the field appdata_source_params as computed. And we were setting this field in the state file. So when we dont provide any value to the field(non-appdata), it was setting “null“ in the statefile. So any update call would change the string “null” → null. Which is not accepted as the param is a string. Hence, it failed. 

```
resource_vdb_group_test.go:15: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # delphix_vdb.new will be updated in-place
          ~ resource "delphix_vdb" "new" {
              - appdata_source_params  = "null" -> null
                id                     = "11-ORACLE_DB_CONTAINER-8"
                name                   = "DBOMSRFB555Erhel8397k8qar8_MZ3"
                # (14 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
```
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
# Solution:
Added the computed flag. Now appdata_source_params doesn't gets set when we dont specify it. It is treated as a computed field if not set explicitly.
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
# Testing
```
=== RUN   TestAccVdb_create_vdb_group_positive
[DELPHIX] [INFO] 2023/05/25 15:29:51 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:29:57 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:04 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:10 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:15 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:21 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:27 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:32 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:38 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:44 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:50 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:30:56 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:02 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:08 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:14 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:20 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:26 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:32 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:37 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:43 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:49 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:31:54 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:32:00 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:32:06 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:32:12 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:32:18 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:32:23 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:32:29 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:32:35 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:32:41 DCT-JobId:b46c1d07e50949199220cf614f59c810 has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/25 15:32:41 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/25 15:32:41 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/25 15:32:42 VdbGroupId: db74a21cc30f400aaa83a3b85de1f802
[DELPHIX] [INFO] 2023/05/25 15:32:47 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/25 15:32:47 VdbGroupId: db74a21cc30f400aaa83a3b85de1f802
[DELPHIX] [INFO] 2023/05/25 15:33:01 DCT-JobId:39690a9e48f746d585bdb6209c7dcc13 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:33:06 DCT-JobId:39690a9e48f746d585bdb6209c7dcc13 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:33:12 DCT-JobId:39690a9e48f746d585bdb6209c7dcc13 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:33:18 DCT-JobId:39690a9e48f746d585bdb6209c7dcc13 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:33:24 DCT-JobId:39690a9e48f746d585bdb6209c7dcc13 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:33:29 DCT-JobId:39690a9e48f746d585bdb6209c7dcc13 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:33:35 DCT-JobId:39690a9e48f746d585bdb6209c7dcc13 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 15:33:41 DCT-JobId:39690a9e48f746d585bdb6209c7dcc13 has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/25 15:33:41 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/25 15:33:42 [OK] Breaking poll - Status 404 reached.
--- PASS: TestAccVdb_create_vdb_group_positive (246.66s)
```
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
