### PR TITLE
HUBS-1816 | Write acceptance tests for appdata vdb provisioning

### DIFF
--- a/internal/provider/resource_vdb_test.go
+++ b/internal/provider/resource_vdb_test.go
@@ -62,10 +62,39 @@ func TestAccVdb_bookmark_provision(t *testing.T) {
 	})
 }
 
+func TestAccVdb_appdata_provision(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccVdbAppDataPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVdbDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDctVDBConfigAppDataBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDctAppDataVdbResourceExists("delphix_vdb.new_appdata"),
+					resource.TestCheckResourceAttr("delphix_vdb.new_appdata", "parent_id", os.Getenv("APPDATA_DATASOURCE_ID"))),
+			},
+		},
+	})
+}
+
 func testAccVdbPreCheck(t *testing.T) {
 	testAccPreCheck(t)
 	if err := os.Getenv("DATASOURCE_ID"); err == "" {
 		t.Fatal("DATASOURCE_ID must be set for vdb acceptance tests")
+	}
+}
+
+func testAccVdbAppDataPreCheck(t *testing.T) {
+	testAccPreCheck(t)
+	if err := os.Getenv("APPDATA_DATASOURCE_ID"); err == "" {
+		t.Fatal("DATASOURCE_ID must be set for vdb acceptance tests")
+	}
+	if err := os.Getenv("APPDATA_SOURCE_PARAMS"); err == "" {
+		t.Fatal("APPDATA_SOURCE_PARAMS must be set for vdb acceptance tests")
+	}
+	if err := os.Getenv("APPDATA_CONFIG_PARAMS"); err == "" {
+		t.Fatal("APPDATA_CONFIG_PARAMS must be set for vdb acceptance tests")
 	}
 }
 
@@ -77,6 +106,20 @@ func testAccCheckDctVDBConfigBasic() string {
     	source_data_id         = "%s"
 	}
 	`, datasource_id)
+}
+
+func testAccCheckDctVDBConfigAppDataBasic() string {
+	appdata_datasource_id := os.Getenv("APPDATA_DATASOURCE_ID")
+	appdata_source_params := os.Getenv("APPDATA_SOURCE_PARAMS")
+	appdata_config_params := os.Getenv("APPDATA_CONFIG_PARAMS")
+	return fmt.Sprintf(`
+	resource "delphix_vdb" "new_appdata" {
+		auto_select_repository = true
+    	source_data_id         = "%s"
+		appdata_source_params  = jsonencode(%s)
+		appdata_config_params  = jsonencode(%s)
+	}
+	`, appdata_datasource_id, appdata_source_params, appdata_config_params)
 }
 
 func testAccCheckDctVDBBookmarkConfigBasic() string {
@@ -172,6 +215,36 @@ func testAccCheckDctVdbResourceExists(n string) resource.TestCheckFunc {
 		parentId := res.GetParentId()
 		if parentId != os.Getenv("DATASOURCE_ID") {
 			return fmt.Errorf("parentId does not match DATASOURCE_ID")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDctAppDataVdbResourceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		vdbId := rs.Primary.ID
+		if vdbId == "" {
+			return fmt.Errorf("No VdbID set")
+		}
+
+		client := testAccProvider.Meta().(*apiClient).client
+
+		res, _, err := client.VDBsApi.GetVdbById(context.Background(), vdbId).Execute()
+
+		if err != nil {
+			return err
+		}
+
+		parentId := res.GetParentId()
+		if parentId != os.Getenv("APPDATA_DATASOURCE_ID") {
+			return fmt.Errorf("parentId does not match APPDATA_DATASOURCE_ID")
 		}
 
 		return nil


### PR DESCRIPTION
# Context:
Writing acceptance test for appdata vdb provisioning.
<!--
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
The acceptance test for provisioning Appdata vdb is missing.
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
# Solution:
Added acceptance tests for provisioning AppData Vdb.

It requires 3 new params:

export APPDATA_DATASOURCE_ID=10-APPDATA_CONTAINER-1

export APPDATA_SOURCE_PARAMS="{mountLocation= \"/mnt/GAT\", postgresPort= 5433, configSettingsStg= [{ propertyName: \"timezone\", value:\"GMT\", commentProperty:false}]}"

export APPDATA_CONFIG_PARAMS="{name = \"Postgres-5433 - /mnt/GAT/data\"}"
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
# Testing:
=== RUN   TestAccVdb_appdata_provision
[DELPHIX] [INFO] 2023/05/25 21:51:08 DCT-JobId:950a7f02bb5c4969bd9aa3cb914c439d has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 21:51:14 DCT-JobId:950a7f02bb5c4969bd9aa3cb914c439d has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 21:51:20 DCT-JobId:950a7f02bb5c4969bd9aa3cb914c439d has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 21:51:26 DCT-JobId:950a7f02bb5c4969bd9aa3cb914c439d has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 21:51:32 DCT-JobId:950a7f02bb5c4969bd9aa3cb914c439d has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 21:51:37 DCT-JobId:950a7f02bb5c4969bd9aa3cb914c439d has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/25 21:51:37 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/25 21:51:38 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/25 21:51:43 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/25 21:51:55 DCT-JobId:52e0c7da17634f5499582e0a59a08cb1 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 21:52:01 DCT-JobId:52e0c7da17634f5499582e0a59a08cb1 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 21:52:06 DCT-JobId:52e0c7da17634f5499582e0a59a08cb1 has Status:STARTED
[DELPHIX] [INFO] 2023/05/25 21:52:12 DCT-JobId:52e0c7da17634f5499582e0a59a08cb1 has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/25 21:52:12 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/25 21:52:13 [OK] Breaking poll - Status 404 reached.
--- PASS: TestAccVdb_appdata_provision (78.43s)

==============================================================

TF_ACC=1 go test $(go list ./... | grep -v 'vendor') -v  -timeout 120m
?       terraform-provider-delphix      [no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccEnvironment_positive
[DELPHIX] [INFO] 2023/05/26 12:33:24 DCT-JobId:12ba797cc1db4e07a400ea3e2731917a has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:33:30 DCT-JobId:12ba797cc1db4e07a400ea3e2731917a has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:33:36 DCT-JobId:12ba797cc1db4e07a400ea3e2731917a has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:33:42 DCT-JobId:12ba797cc1db4e07a400ea3e2731917a has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:33:47 DCT-JobId:12ba797cc1db4e07a400ea3e2731917a has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:33:48 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:33:52 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:34:04 DCT-JobId:075a36b3cd29495a9ad4808486d51277 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:34:09 DCT-JobId:075a36b3cd29495a9ad4808486d51277 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:34:15 DCT-JobId:075a36b3cd29495a9ad4808486d51277 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:34:21 DCT-JobId:075a36b3cd29495a9ad4808486d51277 has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:34:22 [OK] Breaking poll - Status 404 reached.
--- PASS: TestAccEnvironment_positive (71.85s)
=== RUN   TestAccVdb_create_vdb_group_positive
[DELPHIX] [INFO] 2023/05/26 12:34:38 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:34:43 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:34:49 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:34:55 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:01 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:06 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:12 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:18 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:24 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:30 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:35 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:41 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:47 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:53 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:35:58 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:04 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:10 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:16 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:21 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:27 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:33 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:39 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:45 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:51 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:36:57 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:37:02 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:37:08 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:37:14 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:37:20 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:37:25 DCT-JobId:40f4aa3ec42b4c8199ffa935b4eb01ad has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:37:25 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:37:26 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:37:27 VdbGroupId: 7bcf66fa8a5d41e6b275ff2d8cbcb162
[DELPHIX] [INFO] 2023/05/26 12:37:34 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:37:34 VdbGroupId: 7bcf66fa8a5d41e6b275ff2d8cbcb162
[DELPHIX] [INFO] 2023/05/26 12:37:47 DCT-JobId:f139bbf5bb5341fb919ab7b48993dd5d has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:37:53 DCT-JobId:f139bbf5bb5341fb919ab7b48993dd5d has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:37:58 DCT-JobId:f139bbf5bb5341fb919ab7b48993dd5d has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:38:04 DCT-JobId:f139bbf5bb5341fb919ab7b48993dd5d has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:38:10 DCT-JobId:f139bbf5bb5341fb919ab7b48993dd5d has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:38:15 DCT-JobId:f139bbf5bb5341fb919ab7b48993dd5d has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:38:21 DCT-JobId:f139bbf5bb5341fb919ab7b48993dd5d has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:38:27 DCT-JobId:f139bbf5bb5341fb919ab7b48993dd5d has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:38:27 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:38:28 [OK] Breaking poll - Status 404 reached.
--- PASS: TestAccVdb_create_vdb_group_positive (245.81s)
=== RUN   TestAccVdb_provision_positive
[DELPHIX] [INFO] 2023/05/26 12:38:43 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:38:49 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:38:55 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:00 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:06 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:12 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:18 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:24 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:30 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:35 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:41 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:47 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:53 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:39:58 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:04 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:10 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:16 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:21 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:27 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:33 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:39 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:45 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:51 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:40:56 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:41:02 DCT-JobId:cb9793b50f18480cb201bd7eac17c053 has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:41:02 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:41:03 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:41:08 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:41:11 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:41:21 DCT-JobId:b28ba3b616654db49ee562aa0fc0847a has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:41:27 DCT-JobId:b28ba3b616654db49ee562aa0fc0847a has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:41:33 DCT-JobId:b28ba3b616654db49ee562aa0fc0847a has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:41:33 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:41:37 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:41:41 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:41:54 DCT-JobId:5bdd15fab37e420eb0f797e6f91877cb has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:41:59 DCT-JobId:5bdd15fab37e420eb0f797e6f91877cb has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:42:05 DCT-JobId:5bdd15fab37e420eb0f797e6f91877cb has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:42:05 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:42:05 [OK] Breaking poll - Status 404 reached.
--- PASS: TestAccVdb_provision_positive (218.07s)
=== RUN   TestAccVdb_bookmark_provision
[DELPHIX] [INFO] 2023/05/26 12:42:18 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:42:24 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:42:30 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:42:35 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:42:41 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:42:47 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:42:53 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:42:58 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:04 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:10 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:16 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:21 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:27 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:33 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:38 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:44 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:50 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:43:55 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:02 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:07 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:13 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:19 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:25 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:30 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:36 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:42 DCT-JobId:d6ebf236488b4f5aa514e2fe825984ec has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:44:49 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:44:55 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:01 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:06 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:12 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:18 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:24 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:29 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:35 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:41 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:45:47 DCT-JobId:87295775f18346d79b2b7f228d49fe61 has Status:COMPLETED

        resource "delphix_vdb" "vdb_bookmark" {
        provision_type         = "bookmark"
        auto_select_repository = true
        bookmark_id            = "a46e569330ec4f879fa00a864f49d772"
        }
        [DELPHIX] [INFO] 2023/05/26 12:46:03 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:08 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:14 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:20 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:25 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:31 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:37 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:42 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:48 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:54 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:46:59 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:05 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:11 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:16 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:22 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:28 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:34 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:40 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:47 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:52 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:47:58 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:04 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:09 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:15 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:21 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:27 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:33 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:38 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:44 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:50 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:48:56 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:02 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:08 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:14 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:19 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:25 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:31 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:37 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:43 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:48 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:49:54 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:00 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:06 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:11 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:17 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:23 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:29 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:35 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:41 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:46 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:50:52 DCT-JobId:feb18cf7995144ac8c4272cc869d5460 has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:50:52 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:50:53 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:50:58 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:51:11 DCT-JobId:52b28c44cf684256a6326bacc1ecb32a has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:51:16 DCT-JobId:52b28c44cf684256a6326bacc1ecb32a has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:51:22 DCT-JobId:52b28c44cf684256a6326bacc1ecb32a has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:51:22 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:51:23 [OK] Breaking poll - Status 404 reached.
Deleting parent vdb 11-ORACLE_DB_CONTAINER-27--- PASS: TestAccVdb_bookmark_provision (558.57s)
=== RUN   TestAccVdb_appdata_provision
[DELPHIX] [INFO] 2023/05/26 12:51:37 DCT-JobId:f05de43c43d14b059f04dcffd4fc6de3 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:51:43 DCT-JobId:f05de43c43d14b059f04dcffd4fc6de3 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:51:49 DCT-JobId:f05de43c43d14b059f04dcffd4fc6de3 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:51:55 DCT-JobId:f05de43c43d14b059f04dcffd4fc6de3 has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:52:01 DCT-JobId:f05de43c43d14b059f04dcffd4fc6de3 has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:52:01 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:52:01 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:52:06 [OK] Breaking poll - Status 200 reached.
[DELPHIX] [INFO] 2023/05/26 12:52:19 DCT-JobId:0e221bc8d8d746a8a876515d4e823dcc has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:52:25 DCT-JobId:0e221bc8d8d746a8a876515d4e823dcc has Status:STARTED
[DELPHIX] [INFO] 2023/05/26 12:52:31 DCT-JobId:0e221bc8d8d746a8a876515d4e823dcc has Status:COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:52:31 Job result is COMPLETED
[DELPHIX] [INFO] 2023/05/26 12:52:31 [OK] Breaking poll - Status 404 reached.
--- PASS: TestAccVdb_appdata_provision (67.02s)
PASS
ok      terraform-provider-delphix/internal/provider    1162.835s
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
