### PR TITLE
Escl 4868 : Failing Delphix Terraform DCT provider updates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 env:
-  - PROVIDER_VERSION=3.2.0
+  - PROVIDER_VERSION=3.2.1
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=delphix.com
 NAMESPACE=dct
 NAME=delphix
 BINARY=terraform-provider-${NAME}
-VERSION=3.2.0
+VERSION=3.2.1
 OS_ARCH=darwin_amd64
 
 default: install

--- a/docs/resources/appdata_dsource.md
+++ b/docs/resources/appdata_dsource.md
@@ -8,7 +8,10 @@ The Appdata dSource resource allows Terraform to create and delete AppData dSour
 ## System Requirements
 
 * Data Control Tower v10.0.1+ is required for dSource management. Lower versions are not supported.
-* This Appdata dSource Resource only supports Appdata based datasources , such as POSTGRES,SAP HANA, IBM Db2, etc.The below examples are shown from the PostgreSQL context. See the Oracle dSource Resource for the support of Oracle. The Delphix Provider does not support Oracle, SQL Server, or SAP ASE.
+* This Appdata dSource Resource only supports Appdata based datasource's , such as POSTGRES,SAP HANA, IBM Db2, etc.The below examples are shown from the PostgreSQL context. See the Oracle dSource Resource for the support of Oracle. The Delphix Provider does not support Oracle, SQL Server, or SAP ASE.
+
+## Upgrade Guide
+* Any new dSource created post Version>=3.2.1 can set `wait_time` to wait for snapshot creation , dSources created prior to this version will not support this capability 
 
 ## Example Usage
 

--- a/docs/resources/appdata_dsource.md
+++ b/docs/resources/appdata_dsource.md
@@ -183,4 +183,4 @@ resource "delphix_appdata_dsource" "dsource_name" {
 
 * `skip_wait_for_snapshot_creation` - (Optional) By default this resource will wait for a snapshot to be created post-dSource creation. This ensure a snapshot is available during the VDB provisioning. This behavior can be skipped by setting this parameter to `true`.
 
-* `wait_time` - (Optional) By default this resource waits 3 minutes for a snapshot to be created. Increase the integer value as needed for larger dSource snapshots. This parameter can be ignored if 'skip_wait_for_snapshot_creation' is set to `true`.
+* `wait_time` - (Optional) By default this resource waits 0 minutes for a snapshot to be created. Increase the integer value as needed for larger dSource snapshots. This parameter can be ignored if 'skip_wait_for_snapshot_creation' is set to `true`.

--- a/docs/resources/oracle_dsource.md
+++ b/docs/resources/oracle_dsource.md
@@ -197,4 +197,4 @@ resource "delphix_oracle_dsource" "test_oracle_dsource" {
 
 * `skip_wait_for_snapshot_creation` - (Optional) By default this resource will wait for a snapshot to be created post-dSource creation. This ensure a snapshot is available during the VDB provisioning. This behavior can be skipped by setting this parameter to `true`.
 
-* `wait_time` - (Optional) By default this resource waits 3 minutes for a snapshot to be created. Increase the integer value as needed for larger dSource snapshots. This parameter can be ignored if 'skip_wait_for_snapshot_creation' is set to `true`.
+* `wait_time` - (Optional) By default this resource waits 0 minutes for a snapshot to be created. Increase the integer value as needed for larger dSource snapshots. This parameter can be ignored if 'skip_wait_for_snapshot_creation' is set to `true`.

--- a/internal/provider/resource_appdata_dsource.go
+++ b/internal/provider/resource_appdata_dsource.go
@@ -329,7 +329,6 @@ func resourceAppdataDsource() *schema.Resource {
 			},
 			"wait_time": {
 				Type:     schema.TypeInt,
-				Default:  3,
 				Optional: true,
 			},
 			"skip_wait_for_snapshot_creation": {
@@ -557,6 +556,12 @@ func resourceDsourceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		old, _ := d.GetChange(key)
 		d.Set(key, old)
 	}
+
+	//if d.HasChanges("wait_time", "skip_wait_for_snapshot_creation") {
+	//	d.Set("wait_time", 3)
+	//	d.Set("skip_wait_for_snapshot_creation", false)
+	//	return diag.Diagnostics{}
+	//}
 
 	return diag.Errorf("Action update not implemented for resource : dSource")
 }

--- a/internal/provider/resource_appdata_dsource.go
+++ b/internal/provider/resource_appdata_dsource.go
@@ -329,6 +329,7 @@ func resourceAppdataDsource() *schema.Resource {
 			},
 			"wait_time": {
 				Type:     schema.TypeInt,
+				Default:  0,
 				Optional: true,
 			},
 			"skip_wait_for_snapshot_creation": {

--- a/internal/provider/resource_appdata_dsource.go
+++ b/internal/provider/resource_appdata_dsource.go
@@ -557,12 +557,6 @@ func resourceDsourceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		d.Set(key, old)
 	}
 
-	//if d.HasChanges("wait_time", "skip_wait_for_snapshot_creation") {
-	//	d.Set("wait_time", 3)
-	//	d.Set("skip_wait_for_snapshot_creation", false)
-	//	return diag.Diagnostics{}
-	//}
-
 	return diag.Errorf("Action update not implemented for resource : dSource")
 }
 

--- a/internal/provider/resource_oracle_dsource.go
+++ b/internal/provider/resource_oracle_dsource.go
@@ -533,6 +533,7 @@ func resourceOracleDsource() *schema.Resource {
 			},
 			"wait_time": {
 				Type:     schema.TypeInt,
+				Default:  0,
 				Optional: true,
 			},
 			"skip_wait_for_snapshot_creation": {

--- a/internal/provider/resource_oracle_dsource.go
+++ b/internal/provider/resource_oracle_dsource.go
@@ -533,7 +533,6 @@ func resourceOracleDsource() *schema.Resource {
 			},
 			"wait_time": {
 				Type:     schema.TypeInt,
-				Default:  3,
 				Optional: true,
 			},
 			"skip_wait_for_snapshot_creation": {

--- a/internal/provider/resource_vdb_test.go
+++ b/internal/provider/resource_vdb_test.go
@@ -141,8 +141,8 @@ func testAccCheckDctVDBBookmarkConfigBasic() string {
 	vdb_req := client.VDBsApi.ProvisionVdbBySnapshot(context.Background())
 
 	vdb_res, vdb_http_res, vdb_err := vdb_req.ProvisionVDBBySnapshotParameters(*provisionVDBBySnapshotParameters).Execute()
-	if diags := apiErrorResponseHelper(vdb_res, vdb_http_res, vdb_err); diags != nil {
-		println("An error occured during vdb creation: " + vdb_err.Error())
+	if diags := apiErrorResponseHelper(context.Background(), vdb_res, vdb_http_res, vdb_err); diags != nil {
+		println("An error occurred during vdb creation: " + vdb_err.Error())
 		return "" // return empty config to indicate config error
 	}
 	vdb_id = *vdb_res.VdbId
@@ -163,8 +163,8 @@ func testAccCheckDctVDBBookmarkConfigBasic() string {
 	bookmark_req := client.BookmarksApi.CreateBookmark(context.Background()).BookmarkCreateParameters(*bookmark)
 	bk_res, bk_http_res, bk_err := bookmark_req.Execute()
 
-	if diags := apiErrorResponseHelper(bk_res, bk_http_res, bk_err); diags != nil {
-		println("An error occured during bookmark creation: " + bk_err.Error())
+	if diags := apiErrorResponseHelper(context.Background(), bk_res, bk_http_res, bk_err); diags != nil {
+		println("An error occurred during bookmark creation: " + bk_err.Error())
 		return ""
 	}
 	bookmark_id = *bk_res.Bookmark.Id
@@ -173,7 +173,7 @@ func testAccCheckDctVDBBookmarkConfigBasic() string {
 	bk_job_res, bk_job_err := PollJobStatus(*bk_res.Job.Id, context.Background(), client)
 
 	if bk_job_res == Failed || bk_job_res == Canceled || bk_job_res == Abandoned {
-		println("An error occured during bookmark job polling: " + bk_job_err)
+		println("An error occurred during bookmark job polling: " + bk_job_err)
 		return "" // return empty config to indicate config error
 	}
 


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->

in release 3.2.0 we introduced 2 new schema variables in dsource resource , the intention was to use these for a new polling logic where based on these 2 variables we poll for snapshot creation to be completed ,post dsource job polling is completed .

```
"wait_time": {
    Type:     schema.TypeInt,
    Default:  3,
    Optional: true,
},
"skip_wait_for_snapshot_creation": {
    Type:     schema.TypeBool,
    Default:  false,
    Optional: true,
},
```
for the user in case of an upgrade from 3.1.0 -> 3.2.0 "wait_time" is getting added to the state file and identified as a changed attribute which caused the drift and hence the failure, since we have  defined "wait_time" as int with "Default:  3", terraform first adds the value as 0 and then later updates it to 3 which has caused this drift, we don't this drift for "skip_wait_for_snapshot_creation" because it is of type  boolean .

# Solution:
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->

removed the default from "wait_time" i.e it will be assigned to 0 by default and no attribute change will be detected by terraform 

# Testing
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->

upgrade to 3.2.0

```
delphix_appdata_dsource.test_app_data_dsource_second: Refreshing state... [id=13-APPDATA_CONTAINER-160]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # delphix_appdata_dsource.test_app_data_dsource_second will be updated in-place
  ~ resource "delphix_appdata_dsource" "test_app_data_dsource_second" {
        id                              = "13-APPDATA_CONTAINER-160"
        name                            = "appdata_dsource_second_new"
      ~ wait_time                       = 0 -> 3
        # (23 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


```

upgrade to 3.2.1 resolves this 

```
ankit.patil@Ankit-Patils-MacBook-Pro postgresql % terraform plan          
delphix_appdata_dsource.test_app_data_dsource_second: Refreshing state... [id=13-APPDATA_CONTAINER-160]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
ankit.patil@Ankit-Patils-MacBook-Pro postgresql % terraform apply
delphix_appdata_dsource.test_app_data_dsource_second: Refreshing state... [id=13-APPDATA_CONTAINER-160]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

```

Manually tested
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
