### PR TITLE
ESCL-4870 : Terraform dsource provider doesn't support ignore_changes in the lifecycle block

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 env:
-  - PROVIDER_VERSION=3.2.1
+  - PROVIDER_VERSION=3.2.2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=delphix.com
 NAMESPACE=dct
 NAME=delphix
 BINARY=terraform-provider-${NAME}
-VERSION=3.2.1
+VERSION=3.2.2
 OS_ARCH=darwin_amd64
 
 default: install

--- a/docs/resources/appdata_dsource.md
+++ b/docs/resources/appdata_dsource.md
@@ -14,7 +14,7 @@ The Appdata dSource resource allows Terraform to create and delete AppData dSour
 * Any new dSource created post Version>=3.2.1 can set `wait_time` to wait for snapshot creation , dSources created prior to this version will not support this capability 
 
 ## Note
-* `status` and `enabled` are subject to change in the state file based on the dSource state.
+* `status` and `enabled` are subject to change in the tfstate file based on the dSource state.
 
 ## Example Usage
 

--- a/docs/resources/appdata_dsource.md
+++ b/docs/resources/appdata_dsource.md
@@ -13,6 +13,9 @@ The Appdata dSource resource allows Terraform to create and delete AppData dSour
 ## Upgrade Guide
 * Any new dSource created post Version>=3.2.1 can set `wait_time` to wait for snapshot creation , dSources created prior to this version will not support this capability 
 
+## Note
+* `status` and `enabled` are subject to change in the state file based on the dSource state.
+
 ## Example Usage
 
 The linking of a dSource can be configured through various ingestion approaches. Each configuration is customized to the connector and its supported options. The three PostgreSQL parameter sets below show working examples.

--- a/docs/resources/oracle_dsource.md
+++ b/docs/resources/oracle_dsource.md
@@ -10,6 +10,12 @@ The Oracle dSource resource allows Terraform to create and delete Oracle dSource
 * Data Control Tower v10.0.1+ is required for dSource management. Lower versions are not supported.
 * This Oracle dSource Resource only supports Oracle. See the AppData dSource Resource for the support of other connectors (i.e. AppData), such as PostgreSQL and SAP HANA. The Delphix Provider does not support SQL Server or SAP ASE.
 
+## Upgrade Guide
+* Any new dSource created post Version>=3.2.1 can set `wait_time` to wait for snapshot creation , dSources created prior to this version will not support this capability
+
+## Note
+* `status` and `enabled` are subject to change in the state file based on the dSource state.
+
 ## Example Usage
 
 * The linking of a dSource can be performed via direct ingestion as shown in the example below

--- a/docs/resources/oracle_dsource.md
+++ b/docs/resources/oracle_dsource.md
@@ -14,7 +14,7 @@ The Oracle dSource resource allows Terraform to create and delete Oracle dSource
 * Any new dSource created post Version>=3.2.1 can set `wait_time` to wait for snapshot creation , dSources created prior to this version will not support this capability
 
 ## Note
-* `status` and `enabled` are subject to change in the state file based on the dSource state.
+* `status` and `enabled` are subject to change in the tfstate file based on the dSource state.
 
 ## Example Usage
 

--- a/internal/provider/resource_appdata_dsource.go
+++ b/internal/provider/resource_appdata_dsource.go
@@ -283,10 +283,6 @@ func resourceAppdataDsource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"storage_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 			"plugin_version": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -529,7 +525,6 @@ func resourceDsourceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("database_type", result.GetDatabaseType())
 	d.Set("name", result.GetName())
 	d.Set("is_replica", result.GetIsReplica())
-	d.Set("storage_size", result.GetStorageSize())
 	d.Set("plugin_version", result.GetPluginVersion())
 	d.Set("creation_date", result.GetCreationDate().String())
 	d.Set("group_name", result.GetGroupName())

--- a/internal/provider/resource_oracle_dsource.go
+++ b/internal/provider/resource_oracle_dsource.go
@@ -487,10 +487,6 @@ func resourceOracleDsource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"storage_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 			"plugin_version": {
 				Type:     schema.TypeString,
 				Computed: true,


### PR DESCRIPTION
<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->

As per the discussion with customer, they have noticed intermittently that `storage_size` keeps changing even tough the dsource is disabled and this causes their TF plan to fail,when we tried to reproduce locally we don't see an issue as  `storage_size` is a computed field  , but customers  are using github actions where between the TF plan and TF apply stage if any attribute changes the next steps fail .

They tried adding `storage_size` to the` ignore_changes = [storage_size]` block which is a feature provided by Terraform to ignore variables in a particular lifecycle but it only works on non-computed attributes , we have defined `storage_size` as computed so this does not solve the problem for them.



# Solution:
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->

As `storage_size` is not important for infra as code, at this point, this looks like a good solution to remove this attribute and later reintroduce it if required .
# Testing
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
dsoruce in 3.1.0 -> `storage_size` is available

![image](https://github.com/delphix-integrations/terraform-provider-delphix/assets/112482330/d505aa9c-770b-428a-ad74-00fad296590d)

upgrade to 3.2.2 -> `storage_size` removed post plan and apply

![image](https://github.com/delphix-integrations/terraform-provider-delphix/assets/112482330/b2afe9f1-884f-484c-b3f1-e864c14c0c6d)



Manually Tested
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
