### PR TITLE
DLPXECO-11595 | upgraded to sdk2025.1.2 | fork -> develop

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 env:
-  - PROVIDER_VERSION=3.3.1
+  - PROVIDER_VERSION=3.3.2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.6
 
 require (
-	github.com/delphix/dct-sdk-go/v22 v22.0.0
+	github.com/delphix/dct-sdk-go/v25 v25.1.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/delphix/dct-sdk-go/v22 v22.0.0 h1:bHwJ6wVunGte6szxbHMt0E9O/Ox3ydcb02RMdRa3zpc=
-github.com/delphix/dct-sdk-go/v22 v22.0.0/go.mod h1:VHMZm4vQdh8FJj8lsdvbTeCJzy22a6/kjrsIkHmaefg=
+github.com/delphix/dct-sdk-go/v25 v25.1.2 h1:wiJui4cZB4xK9Znu9JdWb5N3rKqbnz1oXWaqLXjGHnE=
+github.com/delphix/dct-sdk-go/v25 v25.1.2/go.mod h1:Y//bIbAZP6SZhLLZAQMxEfeRXvsvKQwu/kSR8a5hfqc=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"net/http"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_appdata_dsource.go
+++ b/internal/provider/resource_appdata_dsource.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_database_postgresql.go
+++ b/internal/provider/resource_database_postgresql.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/resource_oracle_dsource.go
+++ b/internal/provider/resource_oracle_dsource.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/resource_vdb.go
+++ b/internal/provider/resource_vdb.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -1591,7 +1591,7 @@ func resourceVdbRead(ctx context.Context, d *schema.ResourceData, meta interface
 	d.Set("post_stop", flattenHooks(result.GetHooks().PostStop))
 	d.Set("pre_rollback", flattenHooks(result.GetHooks().PreRollback))
 	d.Set("post_rollback", flattenHooks(result.GetHooks().PostRollback))
-	if !*result.IsAppdata {
+	if !result.GetIsAppdata() {
 		d.Set("database_name", result.GetDatabaseName())
 	}
 

--- a/internal/provider/resource_vdb_group.go
+++ b/internal/provider/resource_vdb_group.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/resource_vdb_test.go
+++ b/internal/provider/resource_vdb_test.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"testing"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/internal/provider/utility.go
+++ b/internal/provider/utility.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	dctapi "github.com/delphix/dct-sdk-go/v22"
+	dctapi "github.com/delphix/dct-sdk-go/v25"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"


### PR DESCRIPTION
https://perforce.atlassian.net/browse/DLPXECO-11595

v2025.1.0.0 of DCT with Go SDK Version 22.0 causes the issue

The fix for this bug will use an upgraded Go SDK Version of 25.1.0 generated out of DCT v2025.1.0.0