### PR TITLE
feat: add VDB group update and tag management with acceptance tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.6
 
 require (
-	github.com/delphix/dct-sdk-go/v25 v25.1.2
+	github.com/delphix/dct-sdk-go/v25 v25.2.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/delphix/dct-sdk-go/v25 v25.1.2 h1:wiJui4cZB4xK9Znu9JdWb5N3rKqbnz1oXWaqLXjGHnE=
 github.com/delphix/dct-sdk-go/v25 v25.1.2/go.mod h1:Y//bIbAZP6SZhLLZAQMxEfeRXvsvKQwu/kSR8a5hfqc=
+github.com/delphix/dct-sdk-go/v25 v25.2.0 h1:djFGvJwDHE99vBFa5ZlixcV49niz7nRsuwfue8l/AQA=
+github.com/delphix/dct-sdk-go/v25 v25.2.0/go.mod h1:fCw+bOFPHiNcqUGvRpOEq4PINgcmw6KptstJy4v66Uo=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/internal/provider/resource_vdb_group.go
+++ b/internal/provider/resource_vdb_group.go
@@ -35,18 +35,38 @@ func resourceVdbGroup() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
 func resourceVdbGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	var diags diag.Diagnostics
 
 	client := meta.(*apiClient).client
 
 	vdbGroupCreateReq := *dctapi.NewCreateVDBGroupRequest(d.Get("name").(string))
 	vdbGroupCreateReq.SetVdbIds(toStringArray(d.Get("vdb_ids")))
+
+	if v, has_v := d.GetOk("tags"); has_v {
+		vdbGroupCreateReq.SetTags(toTagArray(v))
+	}
+
 	apiRes, httpRes, err := client.VDBGroupsAPI.CreateVdbGroup(ctx).CreateVDBGroupRequest(vdbGroupCreateReq).Execute()
 
 	if diags := apiErrorResponseHelper(ctx, apiRes, httpRes, err); diags != nil {
@@ -64,7 +84,6 @@ func resourceVdbGroupCreate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceVdbGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	client := meta.(*apiClient).client
 
 	var diags diag.Diagnostics
@@ -80,12 +99,116 @@ func resourceVdbGroupRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.Set("name", apiRes.GetName())
 	d.Set("vdb_ids", apiRes.GetVdbIds())
+	d.Set("tags", flattenTags(apiRes.GetTags()))
 	return diags
 }
 
 func resourceVdbGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*apiClient).client
 
-	return diag.Errorf("not implemented")
+	vdbGroupId := d.Id()
+
+	if d.HasChange("name") || d.HasChange("vdb_ids") {
+		updateVdbGroupReq := *dctapi.NewUpdateVDBGroupParameters()
+		if d.HasChange("name") {
+			updateVdbGroupReq.SetName(d.Get("name").(string))
+		}
+		if d.HasChange("vdb_ids") {
+			updateVdbGroupReq.SetVdbIds(toStringArray(d.Get("vdb_ids")))
+		}
+
+		_, httpRes, err := client.VDBGroupsAPI.UpdateVdbGroupById(ctx, vdbGroupId).UpdateVDBGroupParameters(updateVdbGroupReq).Execute()
+		if diags := apiErrorResponseHelper(ctx, nil, httpRes, err); diags != nil {
+			return diags
+		}
+	}
+
+	if d.HasChange("tags") {
+		oldTags, newTags := d.GetChange("tags")
+		oldTagList := oldTags.([]interface{})
+		newTagList := newTags.([]interface{})
+
+		// Create a map of old tags for easy lookup
+		oldTagMap := make(map[string]map[string]bool)
+		for _, tag := range oldTagList {
+			tagMap := tag.(map[string]interface{})
+			key := tagMap["key"].(string)
+			value := tagMap["value"].(string)
+			if _, exists := oldTagMap[key]; !exists {
+				oldTagMap[key] = make(map[string]bool)
+			}
+			oldTagMap[key][value] = true
+		}
+
+		// Create a map of new tags for easy lookup
+		newTagMap := make(map[string]map[string]bool)
+		for _, tag := range newTagList {
+			tagMap := tag.(map[string]interface{})
+			key := tagMap["key"].(string)
+			value := tagMap["value"].(string)
+			if _, exists := newTagMap[key]; !exists {
+				newTagMap[key] = make(map[string]bool)
+			}
+			newTagMap[key][value] = true
+		}
+
+		// Delete removed tags
+		for key, oldValues := range oldTagMap {
+			newValues, exists := newTagMap[key]
+			if !exists {
+				// Key doesn't exist in new tags, delete all values for this key
+				deleteTag := *dctapi.NewDeleteTag()
+				deleteTag.SetKey(key)
+				httpRes, err := client.VDBGroupsAPI.DeleteVdbGroupTags(ctx, vdbGroupId).DeleteTag(deleteTag).Execute()
+				if diags := apiErrorResponseHelper(ctx, nil, httpRes, err); diags != nil {
+					return diags
+				}
+			} else {
+				// Key exists, delete only values that are not in new tags
+				for oldValue := range oldValues {
+					if !newValues[oldValue] {
+						deleteTag := *dctapi.NewDeleteTag()
+						deleteTag.SetKey(key)
+						deleteTag.SetValue(oldValue)
+						httpRes, err := client.VDBGroupsAPI.DeleteVdbGroupTags(ctx, vdbGroupId).DeleteTag(deleteTag).Execute()
+						if diags := apiErrorResponseHelper(ctx, nil, httpRes, err); diags != nil {
+							return diags
+						}
+					}
+				}
+			}
+		}
+
+		// Create new tags
+		var tags []dctapi.Tag
+		for key, newValues := range newTagMap {
+			oldValues, exists := oldTagMap[key]
+			if !exists {
+				// Key doesn't exist in old tags, create all values
+				for value := range newValues {
+					tag := *dctapi.NewTag(key, value)
+					tags = append(tags, tag)
+				}
+			} else {
+				// Key exists, create only new values
+				for value := range newValues {
+					if !oldValues[value] {
+						tag := *dctapi.NewTag(key, value)
+						tags = append(tags, tag)
+					}
+				}
+			}
+		}
+		if len(tags) > 0 {
+			tagsRequest := *dctapi.NewTagsRequest(tags)
+			_, httpRes, err := client.VDBGroupsAPI.CreateVdbGroupsTags(ctx, vdbGroupId).TagsRequest(tagsRequest).Execute()
+			if diags := apiErrorResponseHelper(ctx, nil, httpRes, err); diags != nil {
+				return diags
+			}
+		}
+	}
+
+	return resourceVdbGroupRead(ctx, d, meta)
 }
 
 func resourceVdbGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_vdb_group_test.go
+++ b/internal/provider/resource_vdb_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccVdb_create_vdb_group_positive(t *testing.T) {
+func TestAccVdbGroup_create_positive(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccVdbPreCheck(t) },
 		Providers:    testAccProviders,
@@ -26,18 +26,204 @@ func TestAccVdb_create_vdb_group_positive(t *testing.T) {
 	})
 }
 
+func TestAccVdbGroup_tags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccVdbPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVdbGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Create VDB group with initial tags
+				Config: testAccCheckDctVDBGroupConfigWithTags(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDctVdbGroupResourceExists("delphix_vdb.test", "delphix_vdb_group.test"),
+					resource.TestCheckResourceAttr("delphix_vdb_group.test", "tags.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs("delphix_vdb_group.test", "tags.*", map[string]string{
+						"key":   "environment",
+						"value": "test",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("delphix_vdb_group.test", "tags.*", map[string]string{
+						"key":   "environment",
+						"value": "dev",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("delphix_vdb_group.test", "tags.*", map[string]string{
+						"key":   "purpose",
+						"value": "testing",
+					}),
+				),
+			},
+			{
+				// Update tags - add new tag, modify existing tag, remove tag
+				Config: testAccCheckDctVDBGroupConfigWithTagsUpdated(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("delphix_vdb_group.test", "tags.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("delphix_vdb_group.test", "tags.*", map[string]string{
+						"key":   "environment",
+						"value": "prod",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("delphix_vdb_group.test", "tags.*", map[string]string{
+						"key":   "owner",
+						"value": "team-a",
+					}),
+				),
+			},
+			{
+				// Remove all tags
+				Config: testAccCheckDctVDBGroupConfigBasicWithName("my-vdb-group-name-2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("delphix_vdb_group.test", "tags.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVdbGroup_update_name(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccVdbPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVdbGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDctVDBGroupConfigBasicWithName("my-vdb-group-original"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("delphix_vdb_group.test", "name", "my-vdb-group-original"),
+				),
+			},
+			{
+				Config: testAccCheckDctVDBGroupConfigBasicWithName("my-vdb-group-renamed"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("delphix_vdb_group.test", "name", "my-vdb-group-renamed"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDctVDBGroupConfigBasic() string {
 	datasource_id := os.Getenv("DATASOURCE_ID")
 	return fmt.Sprintf(`
 	resource "delphix_vdb" "new" {
 		auto_select_repository = true
 		source_data_id         = "%s"
+		name                   = "TESTVDB1"
+		provision_type         = "snapshot"
 	}
 	resource "delphix_vdb_group" "new_group" {
-		name                   = "my-vdb-group-name"
+		name                   = "my-vdb-group-name-1"
 		vdb_ids                = [delphix_vdb.new.id]
 	}
 	`, datasource_id)
+}
+
+func testAccCheckDctVDBGroupConfigWithTags() string {
+	datasource_id := os.Getenv("DATASOURCE_ID")
+	return fmt.Sprintf(`
+	resource "delphix_vdb" "test" {
+		auto_select_repository = true
+		source_data_id = "%s"
+		name = "TESTVDB2"
+		provision_type = "snapshot"
+	}
+
+	resource "delphix_vdb_group" "test" {
+		name = "my-vdb-group-name-2"
+		vdb_ids = [delphix_vdb.test.id]
+
+		tags {
+			key = "environment"
+			value = "test"
+		}
+		tags {
+			key = "environment"
+			value = "dev"
+		}
+		tags {
+			key = "purpose"
+			value = "testing"
+		}
+	}
+	`, datasource_id)
+}
+
+func testAccCheckDctVDBGroupConfigWithTagsUpdated() string {
+	datasource_id := os.Getenv("DATASOURCE_ID")
+	return fmt.Sprintf(`
+	resource "delphix_vdb" "test" {
+		auto_select_repository = true
+		source_data_id = "%s"
+		name = "TESTVDB2"
+		provision_type = "snapshot"
+	}
+
+	resource "delphix_vdb_group" "test" {
+		name = "my-vdb-group-name-2"
+		vdb_ids = [delphix_vdb.test.id]
+
+		tags {
+			key = "environment"
+			value = "prod"
+		}
+		tags {
+			key = "owner"
+			value = "team-a"
+		}
+	}
+	`, datasource_id)
+}
+
+func testAccCheckDctVDBGroupConfigBasicWithName(groupName string) string {
+	datasource_id := os.Getenv("DATASOURCE_ID")
+	return fmt.Sprintf(`
+	resource "delphix_vdb" "test" {
+		auto_select_repository = true
+		source_data_id         = "%s"
+		name                   = "TESTVDB2"
+		provision_type         = "snapshot"
+	}
+	resource "delphix_vdb_group" "test" {
+		name                   = "%s"
+		vdb_ids                = [delphix_vdb.test.id]
+	}
+	`, datasource_id, groupName)
+}
+
+func testAccCheckDctVDBGroupConfigBasicWithVdbId(vdbName string, groupName string) string {
+	datasource_id := os.Getenv("DATASOURCE_ID")
+	return fmt.Sprintf(`
+	resource "delphix_vdb" "%s" {
+		auto_select_repository = true
+		source_data_id         = "%s"
+		name                   = "%s"
+		provision_type         = "snapshot"
+	}
+	resource "delphix_vdb_group" "test" {
+		name                   = "%s"
+		vdb_ids                = [delphix_vdb.%s.id]
+	}
+	`, vdbName, datasource_id, vdbName, groupName, vdbName)
+}
+
+func testAccCheckDctVDBGroupConfigWithTwoVdbs(groupName, vdbName string) string {
+	datasource_id := os.Getenv("DATASOURCE_ID")
+	return fmt.Sprintf(`
+	resource "delphix_vdb" "vdb3" {
+		auto_select_repository = true
+		source_data_id         = "%s"
+		name                   = "TESTVDB3"
+		provision_type         = "snapshot"
+	}
+	resource "delphix_vdb" "vdb4" {
+		auto_select_repository = true
+		source_data_id         = "%s"
+		name                   = "TESTVDB4"
+		provision_type         = "snapshot"
+	}
+	resource "delphix_vdb_group" "test" {
+		name                   = "%s"
+		vdb_ids                = [delphix_vdb.%s.id]
+	}
+	`, datasource_id, datasource_id, groupName, vdbName)
 }
 
 func testAccCheckDctVdbGroupResourceExists(vdbResourceName string, vdbGroupResourceName string) resource.TestCheckFunc {
@@ -99,4 +285,26 @@ func testAccCheckVdbGroupDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func TestAccVdbGroup_update_vdb_ids(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccVdbPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVdbGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDctVDBGroupConfigWithTwoVdbs("my-vdb-group-vdbid", "vdb3"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("delphix_vdb_group.test", "vdb_ids.#", "1"),
+				),
+			},
+			{
+				Config: testAccCheckDctVDBGroupConfigWithTwoVdbs("my-vdb-group-vdbid", "vdb4"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("delphix_vdb_group.test", "vdb_ids.#", "1"),
+				),
+			},
+		},
+	})
 }

--- a/internal/provider/utility.go
+++ b/internal/provider/utility.go
@@ -212,14 +212,14 @@ func flattenDSourceHooks(hooks []dctapi.Hook, oldList []dctapi.SourceOperation) 
 
 func flattenTags(tags []dctapi.Tag) []interface{} {
 	if tags != nil {
-		returnedTags := make([]interface{}, len(tags))
+		result := make([]interface{}, len(tags))
 		for i, tag := range tags {
-			returnedTag := make(map[string]interface{})
-			returnedTag["key"] = tag.GetKey()
-			returnedTag["value"] = tag.GetValue()
-			returnedTags[i] = returnedTag
+			tagMap := make(map[string]interface{})
+			tagMap["key"] = tag.GetKey()
+			tagMap["value"] = tag.GetValue()
+			result[i] = tagMap
 		}
-		return returnedTags
+		return result
 	}
 	return make([]interface{}, 0)
 }


### PR DESCRIPTION
# Add VDB Group Update and Tag Management with Acceptance Tests

## Overview
This PR introduces enhancements to the VDB group resource, focusing on two key areas:

### 1. VDB Group Updates
- Added support for updating a VDB group's name and VDB IDs.
- Implemented acceptance tests to verify that a VDB group's name can be changed and that the group can be updated to reference different VDBs.

### 2. Tag Management
- Improved the tag update logic to handle adding, updating, and removing tags efficiently.
- Added acceptance tests to ensure that tags are correctly applied, updated, and removed from VDB groups.

## Testing
- All acceptance tests for VDB group updates and tag management have been added and verified to pass.
- The tests cover scenarios such as changing the group name, updating VDB IDs, and managing tags.

Note: All changes were generated by claude3.7