### PR TITLE
DLPXECO-14141: gate testAccPreCheck on TF_ACC so unit-test CI passes …

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -32,6 +32,9 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless TF_ACC is set")
+	}
 	if err := os.Getenv("DCT_KEY"); err == "" {
 		t.Fatal("DCT_KEY must be set for acceptance tests")
 	}


### PR DESCRIPTION
<!--
PR title (paste into the GitHub title field, not the body):
DLPXECO-14141: gate testAccPreCheck on TF_ACC so unit-test CI passes without DCT credentials
-->

# Context:

Jira: https://perforce.atlassian.net/browse/DLPXECO-14141

Follow-up from DLPXECO-14115 ([S2 Hard Gate] CI test coverage enforcement for terraform-provider-delphix), which added `.github/workflows/ci.yml`. That CI job runs `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s` on every PR and push to `main` / `develop`. The job is RED on a clean check-out until this ticket lands.

# Problem:

Pre-existing `TestAcc*` tests in `internal/provider/` call `t.Fatal` inside their `PreCheck` functions when DCT env vars are missing (`DCT_KEY`, `DCT_HOST`, `ACC_ENV_ENGINE_ID`, `DATASOURCE_ID`, …). The CI runner has no live DCT credentials, so these `PreCheck` functions fire `t.Fatal` and the tests FAIL instead of being SKIPPED. As a result the `ci / unit-tests` job cannot be green on the full suite, which blocks the CI gate from being usefully enforced via branch protection.

# Solution:

Skip acceptance tests when `TF_ACC` is unset — the standard Terraform Plugin SDK contract — by adding a `TF_ACC` guard at the top of the root `testAccPreCheck`. Because every resource-specific `PreCheck` already calls `testAccPreCheck(t)` as its first statement, guarding that single function short-circuits the whole suite without touching each individual test.

Alternatives considered and rejected: splitting unit and acceptance tests into separate packages (larger churn, out of scope), and rewriting each `PreCheck` individually (redundant — a single-point fix is sufficient).

# Testing

Local CI-equivalent run with no DCT env vars:

```bash
unset TF_ACC DCT_KEY DCT_HOST
go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s
# ok  terraform-provider-delphix                    0.662s   coverage: 0.0% of statements
# ok  terraform-provider-delphix/internal/provider  0.802s   coverage: 2.3% of statements
```

All previously-failing `TestAcc*` tests now report `--- SKIP` (zero FAIL). Coverage holds at **2.3%**, above the documented threshold (2%) in `.github/workflows/ci.yml`.

The acceptance flow is unchanged when `TF_ACC` is set:

```bash
TF_ACC=1 DCT_KEY=… DCT_HOST=… make testacc
```

still runs every test — the guard only fires when `TF_ACC` is empty.

# Implementation:

Added a 3-line skip-guard at the top of `testAccPreCheck` in `internal/provider/provider_test.go`:

```go
func testAccPreCheck(t *testing.T) {
    if os.Getenv("TF_ACC") == "" {
        t.Skip("Acceptance tests skipped unless TF_ACC is set")
    }
    // existing env-var checks…
}
```

`t.Skip` calls `runtime.Goexit`, so once the root guard skips, no downstream `t.Fatal` executes. Every resource-specific `PreCheck` (`testsourcePreCheck`, `testDsourcePreCheck`, `testAccEnvPreCheck`, `testAccVdbPreCheck`, `testAccVdbGroupPreCheck`, `testAccVdbAppDataPreCheck`, `testOracleDsourcePreCheck`) already calls `testAccPreCheck(t)` first, so this single point covers every existing `TestAcc*`.

# Notes To Reviewers:

Single-file change — review `internal/provider/provider_test.go` (3 added lines at the top of `testAccPreCheck`). No production (non-test) code is touched.

# Future work:

- Revisiting `COVERAGE_THRESHOLD` in `.github/workflows/ci.yml` is intentionally deferred to a separate, mechanical follow-up.
- Rewriting the acceptance tests, splitting unit vs. acceptance into separate packages, and adding new test coverage are explicitly out of scope.
