### PR TITLE
Claude.md changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,3 +238,12 @@ configure GitHub.
 | Who can bypass | No one (recommended) |
 
 **The exact status-check string to enter in GitHub's branch protection UI is: `ci / unit-tests`**
+
+### Drift Management
+
+The values in the Workflow Summary table above (threshold, status-check
+string, trigger branches, workflow name, job name) are duplicated from
+`.github/workflows/ci.yml`. Any future PR that changes those values in
+`ci.yml` MUST also update the corresponding rows in this section in the
+same PR. This is a process rule, not a tooling-enforced check — reviewers
+should call out mismatches during PR review.

--- a/docs/DLPXECO-14142-build-output.md
+++ b/docs/DLPXECO-14142-build-output.md
@@ -1,0 +1,33 @@
+# DLPXECO-14142 — Build Output
+
+**Phase**: build
+**Date**: 2026-06-07
+**Branch**: DLPXECO-14141-ci
+
+## Command
+
+```bash
+go build ./...
+```
+
+## Result
+
+- **Exit code**: 0
+- **Stdout/stderr**: (empty — clean build, no warnings, no errors)
+
+## Interpretation
+
+This ticket is doc-only (modifies `CLAUDE.md` only — see `docs/DLPXECO-14142-design.md`).
+A `go build ./...` was executed as a sanity check to confirm no Go source file was
+accidentally touched and the provider package set still compiles.
+
+No source-level impact is expected, and none was observed.
+
+## Adjacent Checks
+
+| Check | Result |
+|---|---|
+| `git diff -- .github/` | empty (FR-007 AC-1, AC-2) |
+| `git diff CLAUDE.md` | 9 insertions, 0 deletions, additive only (FR-001 AC-2) |
+| `grep -c '^## CI Contract$' CLAUDE.md` | `1` (FR-001 AC-1) |
+| `grep -c '^### Drift Management$' CLAUDE.md` | `1` (FR-006 anchor present) |

--- a/docs/DLPXECO-14142-design.md
+++ b/docs/DLPXECO-14142-design.md
@@ -1,0 +1,202 @@
+# DLPXECO-14142 — Design
+
+**Scope**: doc-only change. Locked decision (Option A): modify `CLAUDE.md` only,
+leave `.github/workflows/ci.yml` untouched. All FRs in
+`docs/DLPXECO-14142-functional.md` are satisfied by edits to a single file.
+
+---
+
+## Discovery: Existing State of `CLAUDE.md`
+
+A `## CI Contract` section already exists in `CLAUDE.md` (lines 176–240 at
+HEAD on branch `DLPXECO-14141-ci`). It was introduced by the predecessor work
+DLPXECO-14115 alongside `.github/workflows/ci.yml`. That section already
+contains:
+
+- The `### Workflow Summary` table with all 11 rows from FR-002.
+- The `### Running the Equivalent Check Locally` subsection with all three
+  bash blocks from FR-003.
+- The `### Updating the Coverage Threshold` subsection with the 4-step
+  playbook and the "Do not lower" advisory from FR-004.
+- The `### Branch Protection` subsection with the descriptive paragraph,
+  4-row table, and bold callout from FR-005.
+
+Gap analysis vs. the functional spec:
+
+| FR | Status | Action |
+|---|---|---|
+| FR-001 — section exists | Present (heading + structure) | No-op (the section is already in place; the functional spec's "append" language is satisfied by the existing section because it was added in the same branch lineage that this ticket continues) |
+| FR-002 — workflow summary table | Present, all 11 rows present, all values match `ci.yml` HEAD | No-op |
+| FR-003 — local-reproduction recipe | Present, all three bash blocks, first command byte-identical to FR-002 | No-op |
+| FR-004 — threshold playbook | Present, 4 steps, advisory line present | No-op |
+| FR-005 — branch-protection contract | Present, paragraph + 4-row table + bold callout | No-op |
+| **FR-006 — drift-management note** | **MISSING** — no paragraph instructs contributors to update `CLAUDE.md` when `ci.yml` changes | **ADD** a 1–3 sentence paragraph inside the `CI Contract` section |
+| FR-007 — `ci.yml` untouched | Satisfied by design (we add no edits under `.github/`) | No-op |
+
+The ticket's value-add at the code level reduces to a single small additive
+edit: adding the FR-006 drift-management note. This matches the vision
+(doc-only) and respects all constraints (C1–C5) and non-goals (NG1–NG6).
+
+---
+
+## Architecture Changes
+
+### Source Files to Modify
+
+| File | Change Type | Description |
+|---|---|---|
+| `CLAUDE.md` | Modify (additive only) | Insert one new paragraph (FR-006 drift-management note) inside the existing `## CI Contract` section. Optionally: a one-line wording polish on the existing "Updating the Coverage Threshold" subsection to cross-reference the drift note, if the reviewer prefers — but only as a non-load-bearing nicety. |
+
+### Source Files NOT Modified (explicit)
+
+| File | Reason |
+|---|---|
+| `.github/workflows/ci.yml` | Vision NG1; FR-007 negative requirement. The workflow is the source of truth for behaviour; this ticket is doc-only. |
+| `README.md` | Vision NG5; out of scope. |
+| `pull_request_template.md` | Vision NG5; out of scope. |
+| Any file under `internal/` | Vision NG4; no source changes. |
+| Any file under `examples/` | Vision NG4; no example changes. |
+| `.goreleaser.yml`, `GNUmakefile` | Out of scope (release/build config). |
+| `go.mod` / `go.sum` | No dependency changes. |
+
+### Files Added
+
+None. All work lands in `CLAUDE.md`.
+
+---
+
+## Detailed Edit Plan for `CLAUDE.md`
+
+### Insertion Point
+
+Insert the FR-006 paragraph **immediately after** the existing
+`### Branch Protection` subsection, at the end of the `## CI Contract`
+section. Rationale:
+
+- Placing it last keeps the section's logical flow intact (summary → local
+  repro → threshold playbook → branch protection → process rule).
+- A `### Drift Management` subsection heading (sentence-case, matching the
+  existing subsection style) is added so the rule has a stable anchor for
+  future cross-references and shows up in any TOC generator.
+- This satisfies FR-006 AC-1 ("a reviewer can identify in one read-through
+  what to update if they edit `ci.yml`") because the section ends with a
+  visible, headed paragraph — it does not bury the rule mid-section.
+
+### Exact Content to Add
+
+A new subsection appended after the `### Branch Protection` table and
+callout. The literal block to add (verbatim, no trailing blank line beyond
+what already exists at EOF):
+
+```markdown
+
+### Drift Management
+
+The values in the Workflow Summary table above (threshold, status-check
+string, trigger branches, workflow name, job name) are duplicated from
+`.github/workflows/ci.yml`. Any future PR that changes those values in
+`ci.yml` MUST also update the corresponding rows in this section in the
+same PR. This is a process rule, not a tooling-enforced check — reviewers
+should call out mismatches during PR review.
+```
+
+Notes on wording:
+
+- "MUST" (uppercase) signals a process requirement, matching the convention
+  used elsewhere in `CLAUDE.md` (e.g. the "Commits must be signed" line under
+  Contribution Notes).
+- The paragraph explicitly mentions the five values that are duplicated
+  (threshold, status-check string, trigger branches, workflow name, job
+  name) so a reviewer scanning the diff can immediately see what is in
+  scope.
+- The closing sentence states the rule is process-only, not
+  tool-enforced — satisfying FR-006 AC-2 ("does NOT promise tooling
+  enforcement that does not exist") and matching vision constraint C2.
+
+### Diff Shape
+
+Expected `git diff CLAUDE.md` after the edit:
+
+```
+@@ existing tail of CI Contract section @@
+   **The exact status-check string to enter in GitHub's branch protection UI is: `ci / unit-tests`**
++
++### Drift Management
++
++The values in the Workflow Summary table above (threshold, status-check
++string, trigger branches, workflow name, job name) are duplicated from
++`.github/workflows/ci.yml`. Any future PR that changes those values in
++`ci.yml` MUST also update the corresponding rows in this section in the
++same PR. This is a process rule, not a tooling-enforced check — reviewers
++should call out mismatches during PR review.
+```
+
+Total: 8 lines added, 0 lines removed, 0 lines modified.
+
+---
+
+## Interfaces and Data Models
+
+Not applicable. This is a doc-only change with no code interfaces, schemas,
+or data models. No SDK calls, no resource schema fields, no provider
+registration changes.
+
+---
+
+## Behavioural Impact
+
+| Surface | Before | After |
+|---|---|---|
+| CI workflow execution | Runs unit tests + coverage threshold on PRs to `main`/`develop` and pushes to `main`/`develop` | Identical — `ci.yml` is unchanged |
+| `go build` / `make build` | Builds the provider | Identical — no source changes |
+| `make test` / `make testacc` | Runs unit / acceptance tests | Identical — no test changes |
+| `terraform init` / `terraform apply` against the built provider | Provisions resources via DCT | Identical — no resource-schema changes |
+| Coverage threshold | `2` (per `ci.yml`) | Identical — `ci.yml` is unchanged |
+| Documentation read flow | A contributor reads `## CI Contract` and learns workflow, local repro, threshold playbook, branch protection | A contributor additionally reads the `### Drift Management` paragraph and knows to update `CLAUDE.md` alongside `ci.yml` |
+
+No runtime, build, or test behaviour changes.
+
+---
+
+## Test Plan
+
+See `docs/DLPXECO-14142-test-plan.md` for the per-FR verification matrix.
+Summary:
+
+- All verification is structural (does the doc say X?) and diff-based (does
+  `git diff` touch only the expected files?). No unit tests, no acceptance
+  tests, no new test files.
+- The existing CI workflow (`ci / unit-tests`) continues to provide unit-test
+  + coverage gating; since this ticket adds no Go code, it does not change
+  the coverage total and the threshold (`2`%) remains comfortably satisfied.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Reviewer asks to remove the new "Drift Management" subsection as "obvious" | Medium | Low | Cite vision constraint C2 in the PR description; the constraint explicitly calls out that the drift rule must be documented, not assumed |
+| Reviewer asks to also update `README.md` or `pull_request_template.md` | Medium | Low | Re-affirm vision NG5 in the PR description; offer a follow-up ticket if the team disagrees |
+| Reviewer asks to lower the duplication by removing values from the table and pointing to `ci.yml` instead | Low | Medium — would unwind FR-002 | Cite vision G1 + C1: the whole point of the contract doc is copy-paste-able values. The drift note (FR-006) is the explicit cost-management mechanism for the duplication |
+| Markdown lint / `mdl` config in the repo flags the new paragraph | Low | Low | None expected — wording follows the existing `CLAUDE.md` style (sentence-case `###` headings, prose paragraphs, no exotic constructs). If `mdl` is wired in, fix in place |
+| The existing section already passes all FRs and reviewers ask "why does this ticket need a PR at all?" | Medium | Low | The PR adds the FR-006 paragraph that is genuinely missing from the existing section. Cite the FR-006 row of the gap-analysis table above in the PR description |
+
+---
+
+## Rollback
+
+Trivial: `git revert` the single commit. No data migrations, no schema
+versions, no consumer impact.
+
+---
+
+## Out-of-Scope Confirmations (mirror functional spec)
+
+- No edits to `.github/workflows/ci.yml`.
+- No edits to `README.md`, `pull_request_template.md`, `.goreleaser.yml`,
+  `GNUmakefile`, `main.go`, anything under `internal/`, anything under
+  `examples/`, anything under `docs/resources/` or `docs/guides/`.
+- No change to the coverage threshold value.
+- No new CI jobs, lint configurations, or test files.
+- No programmatic configuration of GitHub branch protection.

--- a/docs/DLPXECO-14142-functional.md
+++ b/docs/DLPXECO-14142-functional.md
@@ -1,0 +1,327 @@
+# Functional Specification: DLPXECO-14142
+
+**Jira**: DLPXECO-14142 — Document the CI contract in `CLAUDE.md`
+**Generated from**: Vision doc (`docs/DLPXECO-14142-vision.md`) — Option A (doc-only),
+dual-branch trigger (`main` + `develop`), `.github/workflows/ci.yml` untouched (NG1).
+
+---
+
+## Scope at a Glance
+
+| Item | Value |
+|---|---|
+| Files modified | `CLAUDE.md` only |
+| Files added | none under `.github/`, `internal/`, `examples/`, `docs/resources/`, `docs/guides/` |
+| Files NOT modified | `.github/workflows/ci.yml`, `README.md`, `pull_request_template.md`, any source under `internal/` |
+| Quality bar | A reviewer can re-derive every documented value from `.github/workflows/ci.yml` HEAD without running anything |
+
+---
+
+## FR-001: Add a "CI Contract" section to `CLAUDE.md`
+
+### Description
+
+Append a new top-level section (heading depth `##`) titled `CI Contract` to
+`CLAUDE.md`, placed after the existing `Useful Links` section and before any
+future trailing sections. The section is the single in-repo authoritative
+reference for what CI does and how to reproduce it locally.
+
+### Input
+
+- Current `CLAUDE.md` content (must be preserved verbatim outside the new section)
+- Current `.github/workflows/ci.yml` content (used as the source of truth for
+  every documented value)
+
+### Processing
+
+1. Read existing `CLAUDE.md` and confirm no section titled `CI Contract` exists.
+2. Append the new section at the end of the file (after `## Useful Links`).
+3. Use the exact heading style (`##` for section, `###` for subsections) and
+   table style (pipe-delimited with `---` separator row) already used elsewhere
+   in `CLAUDE.md`.
+4. Do not reflow or edit any other content in `CLAUDE.md`.
+
+### Output
+
+- `CLAUDE.md` gains exactly one new `## CI Contract` section.
+- `git diff CLAUDE.md` shows only additions (no deletions, no modifications
+  to pre-existing lines).
+
+### Acceptance Criteria
+
+- [ ] AC-1: `CLAUDE.md` contains exactly one heading matching `^## CI Contract$`.
+- [ ] AC-2: All existing content in `CLAUDE.md` is preserved byte-for-byte
+      outside the new section (verified via `git diff` review).
+- [ ] AC-3: No file under `.github/` is modified (verified via
+      `git diff .github/` showing empty output).
+
+---
+
+## FR-002: Document the workflow summary table
+
+### Description
+
+Inside the `CI Contract` section, add a `### Workflow Summary` subsection
+containing a table with one row per documented attribute of the CI workflow.
+
+### Input
+
+- `.github/workflows/ci.yml` HEAD content (workflow name, job name, triggers,
+  runner, Go-version source, test command, artifact name + retention, threshold
+  value).
+
+### Processing
+
+The table MUST include these eight rows, in this order:
+
+| Item | Value |
+|---|---|
+| Workflow file | `` `.github/workflows/ci.yml` `` |
+| Workflow name | `` `ci` `` (matches `name:` in `ci.yml`) |
+| Job name | `` `unit-tests` `` (matches `jobs.unit-tests.name`) |
+| Status-check string | `` `ci / unit-tests` `` (the `<workflow> / <job>` form GitHub requires) |
+| Trigger | `pull_request` to `main` or `develop`; `push` to `main` or `develop` |
+| Runner | `` `ubuntu-latest` `` |
+| Go version | Auto-detected from `go.mod` via `actions/setup-go@v5` |
+| Test command | `` `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s` `` |
+| Coverage artifact | `` `coverage-report` `` (7-day retention) |
+| Coverage threshold | `COVERAGE_THRESHOLD` in `ci.yml` `env:` block (current value: `2`%) |
+| Baseline at threshold set | `2.3%` (measured 2026-06-06; unit tests only, no `TF_ACC`) |
+
+Each value must be reproducible by reading `ci.yml` at the current HEAD.
+
+### Output
+
+- A markdown table rendered cleanly in `CLAUDE.md`.
+- Below the table, one paragraph explicitly stating that acceptance tests
+  (`TF_ACC=1`) are NOT run in CI and noting WHY (no live DCT credentials in
+  CI runners; auto-excluded because the workflow does not export `TF_ACC`).
+
+### Acceptance Criteria
+
+- [ ] AC-1: All eleven rows listed above appear in the table in the order shown.
+- [ ] AC-2: Every value in the table matches the corresponding value in
+      `.github/workflows/ci.yml` at HEAD. (If `ci.yml` changes in the same PR,
+      this AC compares against the post-PR `ci.yml`.)
+- [ ] AC-3: The `TF_ACC` exclusion paragraph immediately follows the table.
+- [ ] AC-4: The trigger row mentions BOTH `main` and `develop` for both
+      `pull_request` and `push` (vision G5, C5).
+
+---
+
+## FR-003: Document the local-reproduction recipe
+
+### Description
+
+Add a `### Running the Equivalent Check Locally` subsection with three
+copy-paste-able shell blocks: the primary recipe (matches CI), the
+per-function breakdown, and the HTML report.
+
+### Input
+
+- The same `go test` command documented in FR-002 (must match exactly).
+
+### Processing
+
+Add three fenced `bash` code blocks, in this order:
+
+1. **Primary recipe** — runs the exact CI command and prints the total coverage line:
+   ```bash
+   go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s
+   go tool cover -func=coverage.out | tail -1
+   ```
+2. **Per-function breakdown** — sorts functions by coverage ascending:
+   ```bash
+   go tool cover -func=coverage.out | sort -t$'\t' -k3 -n
+   ```
+3. **HTML report** — opens an interactive line-by-line coverage view:
+   ```bash
+   go tool cover -html=coverage.out
+   ```
+
+### Output
+
+Three syntactically valid `bash` blocks. The first command must be
+byte-identical to the test command documented in FR-002.
+
+### Acceptance Criteria
+
+- [ ] AC-1: The first command line under the `Running the Equivalent Check
+      Locally` heading is byte-identical to the FR-002 test command.
+- [ ] AC-2: All three code blocks use the fence style `` ```bash `` (matching
+      existing `CLAUDE.md` convention).
+- [ ] AC-3: Running the first block locally in a clean checkout produces a
+      `coverage.out` file and a `total:` line that is comparable to (within
+      noise of) the documented baseline `2.3%` when run without `TF_ACC=1`.
+      (This AC is informational; reviewer may spot-check.)
+
+---
+
+## FR-004: Document the threshold-update playbook
+
+### Description
+
+Add a `### Updating the Coverage Threshold` subsection containing a four-step
+ordered list and a one-sentence team-agreement guard.
+
+### Input
+
+- The location of `COVERAGE_THRESHOLD` (in the `env:` block of `ci.yml`).
+
+### Processing
+
+The subsection MUST contain, in order:
+
+1. An ordered list of exactly four steps:
+   1. Measure current coverage locally using the commands above.
+   2. Edit `COVERAGE_THRESHOLD` in `.github/workflows/ci.yml`.
+   3. Document the old value, new value, and reason in the PR description.
+   4. The change takes effect on the next CI run.
+2. A one-line guard immediately after the list:
+   > Do not lower the threshold without team agreement.
+
+### Output
+
+A 4-step ordered list and a single bold/plain advisory line.
+
+### Acceptance Criteria
+
+- [ ] AC-1: The ordered list contains exactly four items.
+- [ ] AC-2: Step 2 names the file `.github/workflows/ci.yml` (full path).
+- [ ] AC-3: The advisory line appears immediately after step 4.
+- [ ] AC-4: The list does NOT instruct the editor to update `CLAUDE.md`'s
+      threshold value separately — that is covered as a global rule in FR-005
+      (drift management).
+
+---
+
+## FR-005: Document the branch-protection contract
+
+### Description
+
+Add a `### Branch Protection` subsection containing: a one-paragraph
+explanation that branch protection is applied by a repo maintainer in the
+GitHub UI (not by this doc); a table of required settings; and a bold callout
+giving the exact status-check string.
+
+### Input
+
+- The status-check string from FR-002 (`ci / unit-tests`).
+
+### Processing
+
+1. Add an opening paragraph stating that the doc DESCRIBES the contract and
+   does not (cannot) configure GitHub programmatically.
+2. Add a table with the following four rows (in this order):
+
+   | Setting | Required Value |
+   |---|---|
+   | Require status checks to pass before merging | Enabled |
+   | Status check to require | `` `ci / unit-tests` `` |
+   | Require branches to be up to date before merging | Enabled |
+   | Who can bypass | No one (recommended) |
+
+3. Add a bold callout line immediately after the table:
+   > **The exact status-check string to enter in GitHub's branch protection UI is: `ci / unit-tests`**
+
+### Output
+
+Paragraph + 4-row table + bold callout line.
+
+### Acceptance Criteria
+
+- [ ] AC-1: The opening paragraph explicitly states the doc is descriptive,
+      not programmatically enforcing.
+- [ ] AC-2: The table has exactly four rows in the order shown.
+- [ ] AC-3: The bold callout line appears immediately after the table and
+      contains the exact backtick-wrapped string `` `ci / unit-tests` ``.
+- [ ] AC-4: The subsection scope is limited to the `main` branch's contract
+      (matches vision G4 and existing repo convention).
+
+---
+
+## FR-006: Drift-management note (process rule)
+
+### Description
+
+Inside the `CI Contract` section (anywhere reviewer-visible), add a short note
+that any future PR which changes the workflow file, the threshold value, the
+job name, the workflow name, or the trigger branches MUST also update the
+corresponding rows in `CLAUDE.md` in the same PR.
+
+### Input
+
+- Vision constraint C2 (drift risk acknowledgement).
+
+### Processing
+
+Add one short paragraph (1–3 sentences) stating the process rule. Phrase it as
+a contributor instruction, not as a tool-enforced check.
+
+### Output
+
+One paragraph inside the `CI Contract` section.
+
+### Acceptance Criteria
+
+- [ ] AC-1: A reviewer reading the section can identify, in one read-through,
+      what to update in `CLAUDE.md` if they edit `ci.yml`.
+- [ ] AC-2: The note does NOT promise tooling enforcement that does not exist.
+
+---
+
+## FR-007: Confirm `ci.yml` is untouched (negative requirement / NG1)
+
+### Description
+
+This is a negative requirement that holds across the PR.
+
+### Input
+
+- The PR's `git diff` output.
+
+### Processing
+
+CI / reviewer verifies that `git diff --stat` on the merge candidate shows
+ZERO bytes changed under `.github/workflows/`.
+
+### Output
+
+A clean diff scoped to `CLAUDE.md` (and any companion spec files this
+pipeline produces under `docs/`).
+
+### Acceptance Criteria
+
+- [ ] AC-1: `git diff origin/main -- .github/workflows/ci.yml` is empty.
+- [ ] AC-2: `git diff origin/main -- .github/` is empty.
+
+---
+
+## Quality Rules (apply to all FRs)
+
+- **QR-1 — No external links to ephemeral infrastructure.** No links to
+  Jenkins, Buildkite, internal dashboards, or specific GitHub Actions run
+  URLs. (Vision C3.)
+- **QR-2 — Markdown style.** Match existing `CLAUDE.md`: `##` for sections,
+  `###` for subsections, pipe-delimited tables, fenced code blocks with
+  language tag. (Vision C4.)
+- **QR-3 — No behavioural changes.** This ticket adds documentation only. If
+  during review someone discovers a real defect in `ci.yml`, file a new
+  ticket — do not roll a fix into this PR. (Vision NG1.)
+- **QR-4 — Single source of truth for behaviour stays in `ci.yml`.** Where
+  the doc duplicates a value, the value must be reproducible from `ci.yml`
+  HEAD. (Vision C1.)
+- **QR-5 — Trigger description must name both branches explicitly.** Never
+  use "the default branch" or "the protected branch" as a stand-in for
+  `main` / `develop`. (Vision C5, G5.)
+
+---
+
+## Out of Scope (mirrors vision non-goals)
+
+- Editing `.github/workflows/ci.yml` (NG1)
+- Configuring GitHub branch protection programmatically (NG2)
+- Changing the coverage threshold value (NG3)
+- Adding tests, lint, or new CI jobs (NG4)
+- Updating `README.md` or `pull_request_template.md` (NG5)
+- Documenting acceptance tests as part of CI (NG6)

--- a/docs/DLPXECO-14142-test-evidence.md
+++ b/docs/DLPXECO-14142-test-evidence.md
@@ -1,0 +1,97 @@
+# DLPXECO-14142 — Test Evidence
+
+**Phase**: test
+**Date**: 2026-06-07
+**Branch**: DLPXECO-14141-ci
+**Working-tree state**: `CLAUDE.md` modified (+9 lines, 0 deletions); no other repo files modified by this ticket.
+
+This ticket is **doc-only** (see `docs/DLPXECO-14142-design.md`). Verification is structural
+(grep/regex/diff against `CLAUDE.md`) plus the CI-equivalent `go test` repro from FR-003 of
+the functional spec. No new Go tests, fixtures, or test infra were added.
+
+---
+
+## Verification Matrix Results
+
+All checks reference `docs/DLPXECO-14142-test-plan.md`.
+
+| Check | Tied to | Command | Expected | Observed | Result |
+|---|---|---|---|---|---|
+| V-1 | FR-001 AC-1 | `grep -c '^## CI Contract$' CLAUDE.md` | `1` | `1` | PASS |
+| V-2 | FR-001 AC-2 | `git diff CLAUDE.md \| grep -c '^-[^-]'` (deletion count) | `0` | `0` | PASS |
+| V-3 | FR-001 AC-3 / FR-007 AC-1, AC-2 | `git diff -- .github/ \| wc -l` | `0` | `0` | PASS |
+| V-4 | FR-002 AC-1 | Workflow Summary pipe-row count (header+sep+11 data ≥ 13) | `≥13` | `13` | PASS |
+| V-5 | FR-002 AC-2 | Per-row cross-read of table values vs `ci.yml` HEAD | match | match (table from DLPXECO-14115 still mirrors `ci.yml` HEAD; no `ci.yml` change in this PR) | PASS |
+| V-6 | FR-002 AC-3 | `TF_ACC` exclusion paragraph follows the table | present | present at CLAUDE.md L197 | PASS |
+| V-7 | FR-002 AC-4 | Trigger row names main+develop twice | match | `\| Trigger \| pull_request to main or develop; push to main or develop \|` | PASS |
+| V-8 | FR-003 AC-1 | First `go test` under local-repro byte-identical to FR-002 | match | `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s` | PASS |
+| V-9 | FR-003 AC-2 | Three ```` ```bash ```` fences in local-repro subsection | `3` | `3` | PASS |
+| V-10 | FR-003 AC-3 (informational) | Run CI command locally; see V-25 below | `total: ~2.3%` | `total: 2.3%` | PASS |
+| V-11 | FR-004 AC-1 | Threshold playbook has 4 ordered items | `4` | `4` | PASS |
+| V-12 | FR-004 AC-2 | Step 2 names `.github/workflows/ci.yml` | match | match (CLAUDE.md L220) | PASS |
+| V-13 | FR-004 AC-3 | "Do not lower the threshold without team agreement." present | present | present (CLAUDE.md L224) | PASS |
+| V-14 | FR-005 AC-1 | Branch Protection opening paragraph says descriptive, not enforcing | `describes\|configure` match | `This document describes the required contract; it does not programmatically configure GitHub.` | PASS |
+| V-15 | FR-005 AC-2 | Branch Protection pipe-row count (header+sep+4 data ≥ 6) | `≥6` | `6` | PASS |
+| V-16 | FR-005 AC-3 | Bold callout with `ci / unit-tests` immediately after table | present | `**The exact status-check string to enter in GitHub's branch protection UI is: \`ci / unit-tests\`**` | PASS |
+| V-17 | FR-005 AC-4 | Branch Protection subsection mentions `main` | present | 2 occurrences | PASS |
+| V-18 | FR-006 AC-1 | `### Drift Management` present; paragraph enumerates duplicated values | present + 5 values named | `### Drift Management` heading present; paragraph names `threshold`, `status-check string`, `trigger branches`, `workflow name`, `job name` | PASS |
+| V-19 | FR-006 AC-2 | Note explicitly says "process rule" / "not tooling" | match | `This is a process rule, not a tooling-enforced check` | PASS |
+| V-20 | QR-1 | No Jenkins / Buildkite / Actions-run URLs in CI Contract | no matches | rc=1 (grep no match) | PASS |
+| V-21 | QR-2 | Markdown style consistent (`##` / `###` / pipe tables / fenced bash) | visual | consistent — no new constructs | PASS |
+| V-22 | QR-3 | No source/test diff vs HEAD outside `CLAUDE.md` and `docs/` | `0` lines | `0` | PASS |
+| V-23 | QR-4 | All duplicated values reproducible from `ci.yml` HEAD | covered by V-5 | covered | PASS |
+| V-24 | QR-5 | No "default branch" / "the protected branch" stand-ins | no matches | rc=1 (grep no match) | PASS |
+
+**Structural verdict: 24 / 24 PASS.**
+
+---
+
+## V-25: CI-Equivalent Unit-Test Run (FR-003 AC-3 / Pre-Flight #5)
+
+The CI workflow (`.github/workflows/ci.yml`, job `unit-tests`) runs:
+
+```bash
+go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s
+```
+
+The same command was executed locally on the working tree containing my CLAUDE.md
+change. Environment was stripped of `TF_ACC` and per-resource credential env vars
+(`ACC_ENV_ENGINE_ID`, `DATASOURCE_ID`, `ORACLE_DSOURCE_SOURCE_VALUE`) to match
+CI conditions exactly.
+
+### Result
+
+```
+ok    terraform-provider-delphix                       0.887s    coverage: 0.0% of statements
+ok    terraform-provider-delphix/internal/provider    0.884s    coverage: 2.3% of statements
+EXIT=0
+total: (statements) 2.3%
+```
+
+### Baseline Comparison
+
+| Tree state | Total coverage | Exit code |
+|---|---|---|
+| HEAD without DLPXECO-14142 change | `2.3%` | `0` |
+| HEAD with DLPXECO-14142 change | `2.3%` | `0` |
+
+The doc-only edit produced **zero behavioural delta** — coverage is identical to the pre-change baseline, comfortably above the `2%` threshold enforced by `ci.yml`.
+
+### Note on Earlier False Negative
+
+A first invocation of the CI command in this phase produced acceptance-test failures
+(`ACC_ENV_ENGINE_ID must be set`, `DATASOURCE_ID must be set`, …). This was traced to
+environment-variable leakage from the parent shell, not to my edit. After clearing
+those env vars and the test cache (`go clean -testcache`), the command passed on
+both the pre-change and post-change trees. The CI runner has no such env leakage,
+so this would not reproduce in CI.
+
+---
+
+## Files Inspected During Verification
+
+- `CLAUDE.md` (working tree, post-edit)
+- `.github/workflows/ci.yml` (HEAD; not modified — confirmed by `git diff -- .github/`)
+- `docs/DLPXECO-14142-design.md`
+- `docs/DLPXECO-14142-functional.md`
+- `docs/DLPXECO-14142-test-plan.md`

--- a/docs/DLPXECO-14142-test-plan.md
+++ b/docs/DLPXECO-14142-test-plan.md
@@ -1,0 +1,76 @@
+# DLPXECO-14142 — Test Plan
+
+Scope: doc-only change. All verification is structural (grep / regex /
+diff) against `CLAUDE.md` and the repo's `.github/` tree. No Go unit
+tests, no acceptance tests, no new test files are added.
+
+The existing CI workflow (`ci / unit-tests`) continues to gate unit-test
++ coverage on the PR for free; it does not need a new test for this
+ticket because no Go code is modified.
+
+---
+
+## Verification Matrix
+
+| Check ID | Tied to | What to verify | How to verify |
+|---|---|---|---|
+| V-1 | FR-001 AC-1 | `CLAUDE.md` has exactly one `^## CI Contract$` heading | `grep -c '^## CI Contract$' CLAUDE.md` returns `1` |
+| V-2 | FR-001 AC-2 | All existing content outside the additive edit is preserved byte-for-byte | `git diff -- CLAUDE.md` shows only additions inside `## CI Contract`; no deletions outside the new subsection |
+| V-3 | FR-001 AC-3 / FR-007 AC-1 / AC-2 | `.github/` is untouched | `git diff origin/main -- .github/` produces empty output; `git diff origin/main -- .github/workflows/ci.yml` produces empty output |
+| V-4 | FR-002 AC-1 | The Workflow Summary table has all 11 rows in order | Visual inspection + `awk '/^### Workflow Summary$/,/^### Running/' CLAUDE.md \| grep -c '^\|'` returns at least `13` (1 header + 1 separator + 11 data rows) |
+| V-5 | FR-002 AC-2 | Each table value matches `ci.yml` HEAD | Manual cross-read: `Workflow name` row matches `name:` in `ci.yml`; `Job name` row matches `jobs.unit-tests.name`; `Trigger` row matches `on.pull_request.branches` + `on.push.branches`; `Test command` matches the shell command under `Run unit tests with coverage`; `Coverage artifact` matches `actions/upload-artifact@v4 name:`; `Coverage threshold` value matches `env.COVERAGE_THRESHOLD` |
+| V-6 | FR-002 AC-3 | The `TF_ACC` exclusion paragraph follows the table | `grep -A1 'no \`TF_ACC\`' CLAUDE.md` (or visual) shows the paragraph immediately after the table |
+| V-7 | FR-002 AC-4 | Trigger row names both `main` and `develop` for both `pull_request` and `push` | Grep: `grep -E 'Trigger.*main.*develop.*main.*develop' CLAUDE.md` returns a match |
+| V-8 | FR-003 AC-1 | First bash command under `Running the Equivalent Check Locally` is byte-identical to FR-002 test command | `awk '/^### Running the Equivalent/,/^### Updating/' CLAUDE.md \| grep -m1 '^go test '` returns `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s` |
+| V-9 | FR-003 AC-2 | All three code blocks use ` ```bash ` fence | `awk '/^### Running the Equivalent/,/^### Updating/' CLAUDE.md \| grep -c '^```bash$'` returns `3` |
+| V-10 | FR-003 AC-3 (informational) | Local recipe produces a coverage.out and a total line | `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s && go tool cover -func=coverage.out \| tail -1` prints a `total:` line in the same ballpark as the documented baseline `2.3%` (within ±0.5 percentage points when run without `TF_ACC=1`) |
+| V-11 | FR-004 AC-1 | Threshold playbook has exactly four ordered-list items | `awk '/^### Updating the Coverage Threshold$/,/^### Branch Protection$/' CLAUDE.md \| grep -cE '^[1-4]\. '` returns `4` |
+| V-12 | FR-004 AC-2 | Step 2 names the file `.github/workflows/ci.yml` | `awk '/^### Updating the Coverage Threshold$/,/^### Branch Protection$/' CLAUDE.md \| grep -F '.github/workflows/ci.yml'` returns a match |
+| V-13 | FR-004 AC-3 | "Do not lower the threshold without team agreement" appears immediately after step 4 | Visual inspection; grep for the exact phrase |
+| V-14 | FR-005 AC-1 | Branch Protection opening paragraph says the doc is descriptive, not enforcing | `awk '/^### Branch Protection$/,/^### Drift Management$/' CLAUDE.md \| grep -E 'describes|contract|not.*configure'` returns at least one match |
+| V-15 | FR-005 AC-2 | Branch Protection table has exactly four rows in the documented order | `awk '/^### Branch Protection$/,/^### Drift Management$/' CLAUDE.md \| grep -c '^\|'` returns at least `6` (header + separator + 4 data rows) |
+| V-16 | FR-005 AC-3 | Bold callout `ci / unit-tests` line follows the table | `grep -F '**The exact status-check string to enter in GitHub' CLAUDE.md` returns a match; the line contains `` `ci / unit-tests` `` |
+| V-17 | FR-005 AC-4 | Subsection talks about `main` branch | `awk '/^### Branch Protection$/,/^### Drift Management$/' CLAUDE.md \| grep -F 'main'` returns a match |
+| V-18 | FR-006 AC-1 | A reviewer can identify in one read-through what to update if `ci.yml` changes | `grep -F 'Drift Management' CLAUDE.md` returns a match; the paragraph explicitly enumerates the duplicated values (threshold, status-check string, trigger branches, workflow name, job name) |
+| V-19 | FR-006 AC-2 | The note does NOT promise tooling enforcement | `awk '/^### Drift Management$/,/^$/' CLAUDE.md \| grep -iE 'process rule|not.*tooling'` returns a match (positive assertion of process-only nature) |
+| V-20 | QR-1 | No links to Jenkins / Buildkite / internal dashboards / specific Actions run URLs in the new section | `awk '/^## CI Contract$/,EOF' CLAUDE.md \| grep -iE 'jenkins\|buildkite\|actions/runs/'` returns no matches |
+| V-21 | QR-2 | Markdown style is consistent | Visual inspection: `##` for section, `###` for subsections, pipe-delimited tables, fenced `` ```bash `` blocks |
+| V-22 | QR-3 | No behavioural code changes | `git diff origin/main -- ':!CLAUDE.md' ':!docs/'` returns empty |
+| V-23 | QR-4 | All duplicated values are reproducible from `ci.yml` HEAD | Covered by V-5 |
+| V-24 | QR-5 | Trigger description names both branches; never uses "default branch" / "protected branch" as a stand-in | `grep -iE 'default branch\|the protected branch' CLAUDE.md` returns no matches in the new section |
+
+---
+
+## Pre-Flight Sanity (run locally before raising PR)
+
+```bash
+# 1. Confirm only CLAUDE.md (and docs/) are touched
+git diff --stat origin/main -- ':!docs/' | grep -v '^ CLAUDE.md ' && echo "FAIL: extra files touched" || echo "PASS: only CLAUDE.md modified outside docs/"
+
+# 2. Confirm .github/ is empty in the diff
+git diff origin/main -- .github/ | wc -l  # expect 0
+
+# 3. Confirm exactly one CI Contract heading
+grep -c '^## CI Contract$' CLAUDE.md       # expect 1
+
+# 4. Confirm Drift Management subsection was added
+grep -c '^### Drift Management$' CLAUDE.md  # expect 1
+
+# 5. Local CI repro (unit tests + coverage)
+go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s
+go tool cover -func=coverage.out | tail -1  # expect total ≈ 2.3%, > 2% threshold
+```
+
+All checks must return the expected values before raising the PR.
+
+---
+
+## CI Behaviour Expectations
+
+| Aspect | Expectation |
+|---|---|
+| `ci / unit-tests` status check | PASS — no Go code changed; coverage unchanged from current baseline `2.3%`, comfortably above the `2%` threshold |
+| `codeql.yml` (if it runs) | PASS — no code changed |
+| Any markdown lint hook | PASS — wording matches existing `CLAUDE.md` style |
+
+No new CI jobs are added; no thresholds are raised; no tests are added.

--- a/docs/DLPXECO-14142-validation.md
+++ b/docs/DLPXECO-14142-validation.md
@@ -1,0 +1,154 @@
+# DLPXECO-14142 — Validation Report
+
+**Phase**: validate
+**Date**: 2026-06-07
+**Branch**: DLPXECO-14141-ci
+**Diff under review**: working-tree change to `CLAUDE.md` (+9 / -0).
+
+---
+
+## 1. Scope Compliance
+
+| Constraint | Spec source | Observed | Verdict |
+|---|---|---|---|
+| Only `CLAUDE.md` is modified | design.md §"Architecture Changes" | `git diff --stat` lists `CLAUDE.md` and only `CLAUDE.md` outside `docs/` and `.claude/` | PASS |
+| `.github/workflows/ci.yml` untouched | FR-007 / vision NG1 | `git diff -- .github/` empty | PASS |
+| `README.md`, `pull_request_template.md` untouched | vision NG5 | unchanged | PASS |
+| Nothing under `internal/` modified | vision NG4 | unchanged in this ticket's diff | PASS |
+| Nothing under `examples/` modified | vision NG4 | unchanged | PASS |
+| Coverage threshold value unchanged | vision NG3 | `ci.yml` unchanged → threshold still `2%` | PASS |
+| No new CI jobs / lint configs / test files | vision NG4 | none added | PASS |
+
+---
+
+## 2. FR-by-FR Coverage
+
+| FR | Status | Evidence |
+|---|---|---|
+| FR-001 — `## CI Contract` section exists | PASS | One heading, structure intact (V-1, V-2) |
+| FR-002 — Workflow Summary table | PASS | 11 rows, values mirror `ci.yml` HEAD (V-4, V-5, V-6, V-7) |
+| FR-003 — Local-reproduction recipe | PASS | All three bash blocks, first command byte-identical to FR-002 (V-8, V-9, V-10) |
+| FR-004 — Threshold-update playbook | PASS | 4 ordered steps + guard line (V-11, V-12, V-13) |
+| FR-005 — Branch-protection contract | PASS | Descriptive paragraph + 4-row table + bold callout (V-14, V-15, V-16, V-17) |
+| FR-006 — Drift-management note | PASS | `### Drift Management` subsection added; enumerates the 5 duplicated values; explicitly process-only (V-18, V-19) |
+| FR-007 — `ci.yml` untouched (negative) | PASS | `git diff -- .github/workflows/ci.yml` empty (V-3) |
+
+All 7 FRs satisfied.
+
+---
+
+## 3. Quality-Rule Compliance
+
+| QR | Verdict | Note |
+|---|---|---|
+| QR-1 — No links to ephemeral infra | PASS | No Jenkins/Buildkite/Actions-run URLs (V-20) |
+| QR-2 — Markdown style matches existing `CLAUDE.md` | PASS | `##` section, `###` subsection, pipe tables, ```` ```bash ```` fences (V-21) |
+| QR-3 — No behavioural code changes | PASS | `git diff HEAD -- ':!CLAUDE.md' ':!docs/'` returns 0 lines (V-22) |
+| QR-4 — Single source of truth in `ci.yml` | PASS | All duplicated values reproducible from `ci.yml` HEAD (V-23) |
+| QR-5 — Trigger names both branches explicitly | PASS | No "default branch"/"protected branch" stand-ins (V-24) |
+
+---
+
+## 4. CI Equivalent Verification
+
+Command (matches `ci.yml`):
+
+```bash
+go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s
+```
+
+- Exit: `0`
+- `terraform-provider-delphix/internal/provider`: PASS, `2.3%` coverage
+- `terraform-provider-delphix` (root): PASS, `0.0%` (expected — no testable statements in `main.go`)
+- Aggregate `total:` line: `2.3%`
+- Threshold: `2%` (per `ci.yml` env block)
+- Margin above threshold: `+0.3 pp` (consistent with the documented baseline)
+
+CI behaviour expectation: **`ci / unit-tests` will report PASS on the PR.**
+
+---
+
+## 5. Diff Inspection
+
+```
+ CLAUDE.md | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+```
+
+Hunk:
+
+```diff
+@@ -238,3 +238,12 @@ configure GitHub.
+ | Who can bypass | No one (recommended) |
+ 
+ **The exact status-check string to enter in GitHub's branch protection UI is: `ci / unit-tests`**
++
++### Drift Management
++
++The values in the Workflow Summary table above (threshold, status-check
++string, trigger branches, workflow name, job name) are duplicated from
++`.github/workflows/ci.yml`. Any future PR that changes those values in
++`ci.yml` MUST also update the corresponding rows in this section in the
++same PR. This is a process rule, not a tooling-enforced check — reviewers
++should call out mismatches during PR review.
+```
+
+Additive only. Insertion point matches the design ("immediately after the existing
+`### Branch Protection` subsection, at the end of the `## CI Contract` section").
+
+---
+
+## 6. Risk Re-Check (from design.md §"Risks and Mitigations")
+
+| Risk | Status post-implementation |
+|---|---|
+| Reviewer asks to remove `### Drift Management` as "obvious" | Mitigation language ready in PR body (cite vision C2) |
+| Reviewer requests `README.md` / `pull_request_template.md` edits | Mitigation language ready (cite vision NG5; offer follow-up ticket) |
+| Reviewer requests removing duplication and pointing to `ci.yml` | Mitigation language ready (cite G1 + C1; drift note is the explicit duplication-cost mechanism) |
+| Markdown-lint flags the new paragraph | Not present in repo (no `.mdlrc`, no markdown-lint workflow); risk does not materialize |
+| Reviewer questions need for PR | Mitigation: gap-analysis table in design.md shows FR-006 was genuinely missing |
+
+No new risks introduced.
+
+---
+
+## 7. Documentation Coverage (Spec → Code Map)
+
+| Spec artefact | Code/doc location |
+|---|---|
+| FR-001 | `CLAUDE.md` L176 (`## CI Contract` heading) |
+| FR-002 | `CLAUDE.md` L181–195 (`### Workflow Summary` + 11-row table) |
+| FR-002 AC-3 | `CLAUDE.md` L197–198 (`TF_ACC` exclusion paragraph) |
+| FR-003 | `CLAUDE.md` L200–215 (3 bash blocks) |
+| FR-004 | `CLAUDE.md` L217–224 (4-step list + guard) |
+| FR-005 | `CLAUDE.md` L226–240 (paragraph + table + callout) |
+| FR-006 | `CLAUDE.md` L242–249 (`### Drift Management` subsection — **this ticket's net new content**) |
+| FR-007 | `git diff -- .github/` empty (negative requirement) |
+
+100% spec coverage.
+
+---
+
+## 8. Open Issues / Warnings
+
+None. No deferred items, no follow-up tickets, no caveats beyond those already captured in the design's "Risks and Mitigations" section.
+
+---
+
+## 9. Pre-Flight Sanity (from test-plan.md)
+
+| Check | Expected | Observed | Verdict |
+|---|---|---|---|
+| Only `CLAUDE.md` (and `docs/`) touched | only `CLAUDE.md` outside `docs/` and `.claude/` | confirmed via `git diff --stat` | PASS |
+| `.github/` empty in diff | 0 lines | 0 | PASS |
+| Exactly one `## CI Contract` heading | 1 | 1 | PASS |
+| `### Drift Management` subsection added | 1 | 1 | PASS |
+| Local CI repro passes above threshold | `≥ 2%` | `2.3%`, exit 0 | PASS |
+
+---
+
+## Overall Verdict: PASS
+
+All 7 FRs satisfied. All 5 QRs satisfied. 24/24 structural checks PASS. CI-equivalent run PASS with coverage `2.3%` above the `2%` threshold. Diff scope strictly limited to `CLAUDE.md` (+9 lines, 0 deletions) and `docs/DLPXECO-14142-*.md` spec/evidence files. `.github/workflows/ci.yml` and all other constrained files are byte-unchanged.
+
+Cleared to raise PR.

--- a/docs/DLPXECO-14142-vision.md
+++ b/docs/DLPXECO-14142-vision.md
@@ -1,0 +1,159 @@
+# DLPXECO-14142 — Vision
+
+## Summary
+
+Document the CI contract for the `terraform-provider-delphix` repository so that
+contributors, reviewers, and repo maintainers have a single authoritative reference
+for **what runs in CI, when it runs, how to reproduce it locally, and what status
+check must be required by branch protection**.
+
+This is a **doc-only enhancement**. The CI workflow file (`.github/workflows/ci.yml`)
+is already in place and is **not modified** by this work — the source of truth for
+behaviour stays in `ci.yml`. This ticket exists to make that behaviour discoverable
+and reviewable from `CLAUDE.md` (and downstream from the README / contributor docs).
+
+---
+
+## Problem
+
+`ci.yml` was added by DLPXECO-14115 (predecessor ticket on branch `DLPXECO-14142-ci`)
+to run unit tests with coverage enforcement on every PR. The workflow works, but:
+
+1. **Discoverability gap** — a new contributor reading `CLAUDE.md` sees build and
+   test commands but no statement of what CI actually runs, on which branches, or
+   what status check name a maintainer must wire into branch protection.
+2. **Branch-protection ambiguity** — the exact status-check string GitHub expects
+   (`ci / unit-tests`, i.e. `<workflow-name> / <job-name>`) is non-obvious and
+   easy to mistype. Without it documented, a maintainer configuring branch
+   protection can paste the wrong string, silently disabling the gate.
+3. **Reproducibility gap** — the test command and coverage-threshold logic live
+   only in YAML. A contributor wanting to reproduce CI locally before pushing has
+   to read the workflow and reconstruct the command by hand.
+4. **Threshold-change ambiguity** — the process for raising/lowering
+   `COVERAGE_THRESHOLD` is not written down. Anyone editing it currently has to
+   infer the convention (measure → edit → document in PR).
+
+The cost of leaving this undocumented is small per-incident but compounding:
+every new contributor pays the discovery tax, and every branch-protection setup
+or threshold change risks a quiet mistake.
+
+---
+
+## Goals
+
+1. **G1 — Authoritative CI contract in `CLAUDE.md`.** Add a "CI Contract" section
+   to `CLAUDE.md` that enumerates: workflow file path, workflow name, job name,
+   status-check string, trigger events, runner, Go version source, test command,
+   coverage artifact name + retention, threshold env var location, and the
+   baseline coverage measured at the time the threshold was set.
+2. **G2 — Local-reproduction recipe.** Document the exact local commands a
+   contributor can run to reproduce CI's pass/fail decision (`go test ...
+   -coverprofile=...` followed by `go tool cover -func=...`), including the
+   per-function and HTML report variants.
+3. **G3 — Threshold-update playbook.** Document the four-step process for
+   updating `COVERAGE_THRESHOLD` (measure → edit `ci.yml` → document in PR →
+   takes effect next run) and the team-agreement rule for lowering it.
+4. **G4 — Branch-protection contract.** Document the required branch-protection
+   settings for `main` (and call out that a repo maintainer must apply them in
+   the GitHub UI — the doc describes the contract, it does not configure
+   GitHub). Surface the exact status-check string verbatim so it can be copy-
+   pasted into the GitHub UI.
+5. **G5 — Dual-branch coverage.** The documented contract must accurately
+   describe that CI runs on both `main` **and** `develop` (matching `ci.yml`
+   triggers `pull_request: {branches: [main, develop]}` and
+   `push: {branches: [main, develop]}`), so the doc does not become stale the
+   moment someone opens a PR targeting `develop`.
+
+---
+
+## Non-Goals (NG)
+
+1. **NG1 — Do not modify `.github/workflows/ci.yml`.** The workflow is the source
+   of truth for CI behaviour. This ticket only documents what is already there.
+   Any behavioural change (new jobs, threshold change, new triggers) is a
+   separate ticket.
+2. **NG2 — Do not configure GitHub branch protection programmatically.** Branch
+   protection is applied by a repo maintainer in the GitHub UI. The doc states
+   the required contract; it does not (and cannot, from this repo) enforce it.
+3. **NG3 — Do not change the coverage threshold value.** The current value (`2`,
+   measured baseline `2.3%`) stays as set by DLPXECO-14115. Raising the floor is
+   a separate decision.
+4. **NG4 — Do not add new tests, lint configuration, or new CI jobs.** Out of
+   scope for a doc-only ticket.
+5. **NG5 — Do not modify the README or `pull_request_template.md`.** Those are
+   contributor-facing surfaces with their own review owners; updating them is a
+   follow-up if/when the team decides `CLAUDE.md` should be cross-referenced.
+6. **NG6 — Do not document acceptance tests (`TF_ACC=1`) as part of CI.** They
+   are intentionally excluded from CI (no live DCT credentials in runners); the
+   doc must state this exclusion explicitly so future contributors don't try to
+   "fix" it.
+
+---
+
+## Constraints
+
+1. **C1 — Single source of truth for behaviour.** When the doc describes a value
+   (threshold, trigger branches, job name), it must phrase it as "current value
+   in `ci.yml`" rather than restating the YAML, OR it must commit to keeping the
+   two in sync. We choose the latter for the small set of values that matter
+   (threshold, status-check string, trigger branches) because copy-paste-able
+   exact values are the whole point of the doc.
+2. **C2 — Drift risk acknowledgement.** Because we duplicate a small number of
+   values from `ci.yml` into `CLAUDE.md`, any future PR that changes those
+   values in `ci.yml` MUST also update `CLAUDE.md` in the same PR. This is a
+   process rule, not a tooling enforcement; we accept the residual drift risk
+   as the cost of having a copy-paste-able contract doc.
+3. **C3 — No external links to mutable infrastructure.** The doc must not link
+   to internal Delphix Jenkins/Buildkite/etc. dashboards or to ephemeral GitHub
+   Actions run URLs. All references stay inside the repo (`ci.yml`, `go.mod`,
+   `GNUmakefile`) or to stable public docs (Terraform Registry, DCT SDK,
+   `actions/setup-go`).
+4. **C4 — Markdown style consistency with existing `CLAUDE.md`.** Use the same
+   heading depth, table style, and code-block fencing as the existing sections
+   (Build & Test Commands, Provider Resources, Key Architectural Patterns) so
+   the new section reads as a natural continuation, not a bolt-on.
+5. **C5 — Dual-branch wording must be unambiguous.** The trigger description
+   must say "PRs to `main` or `develop`" and "pushes to `main` or `develop`"
+   explicitly — not "PRs to the default branch" or "PRs to the protected
+   branch", because the project uses both `main` and `develop` per
+   `CONTRIBUTION NOTES` ("branch from `develop` for features, `main` for
+   bugfixes").
+
+---
+
+## Risks
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | Doc and `ci.yml` drift after a future threshold change | Medium | Low — CI still gates correctly; only the doc misleads | Add an explicit note in the threshold-update playbook (G3) instructing the editor to update both files in the same PR. |
+| R2 | A maintainer pastes the wrong status-check string into branch protection (e.g. `unit-tests` instead of `ci / unit-tests`) | Low | High — gate silently disabled | Surface the exact string in a dedicated bold callout: "The exact status-check string to enter in GitHub's branch protection UI is: `ci / unit-tests`". |
+| R3 | Contributor reads the doc, runs the local command, sees lower coverage than CI (because CI excludes `TF_ACC`) and assumes regression | Low | Low — confusion only | Document explicitly that the baseline (`2.3%`) was measured without `TF_ACC`, matching CI's behaviour. Add a side-note that running with `TF_ACC=1` locally will show a higher number that is not comparable to CI. |
+| R4 | `ci.yml` is later renamed or its job is later renamed, invalidating the status-check string | Low | High — same as R2 | Same mitigation as C2: process rule that any rename must update `CLAUDE.md` in the same PR. Cannot be enforced from this ticket. |
+| R5 | Scope creep — reviewer asks for README + PR-template updates during review | Medium | Low — delays merge | Reaffirm NG5 in the PR description; offer to file follow-up ticket(s) if the team agrees those surfaces also need the cross-reference. |
+
+---
+
+## Acceptance Criteria (overview — full FR-level criteria in functional.md)
+
+A reviewer should be able to verify the following from the resulting PR diff alone:
+
+- `CLAUDE.md` gains a `## CI Contract` section (or equivalent heading) containing
+  all eight items listed in G1.
+- The section includes a copy-paste-able local-reproduction command block (G2).
+- The section includes the four-step threshold-update playbook (G3).
+- The section includes a branch-protection subsection with the exact required
+  status-check string surfaced in a bold/callout style (G4, R2).
+- The trigger description explicitly names both `main` and `develop` for both
+  `pull_request` and `push` (G5, C5).
+- `.github/workflows/ci.yml` is **not** modified (NG1) — `git diff` shows
+  changes only under `CLAUDE.md` (and any companion spec files under `docs/`).
+- No new files are added under `.github/`, `internal/`, or `examples/` (NG4).
+
+---
+
+## Open Questions
+
+None. The decision to keep this doc-only (Option A), to trigger CI on both
+`main` and `develop` (matching the already-merged `ci.yml`), and to leave
+`ci.yml` untouched is locked per the user's explicit confirmation. Any
+deviation requires a new ticket.


### PR DESCRIPTION
<!--
PR title (paste into the GitHub title field, not the body):
DLPXECO-14142: document drift-management rule in CI Contract
-->

# Context:

Jira: https://perforce.atlassian.net/browse/DLPXECO-14142

`CLAUDE.md` already contains a `## CI Contract` section (added in DLPXECO-14115 alongside `.github/workflows/ci.yml`). That section documents the workflow summary, the local-reproduction recipe, the threshold-update playbook, and the branch-protection contract. However, the section does **not** state the process rule that any future PR which edits `ci.yml` must also update the duplicated values in `CLAUDE.md` in the same PR. DLPXECO-14142 fills that gap.

This is a doc-only ticket — no code, no `ci.yml`, and no test changes.

# Problem:

The `CI Contract` section in `CLAUDE.md` duplicates five values from `.github/workflows/ci.yml` (coverage threshold, status-check string, trigger branches, workflow name, job name). Today there is no in-repo instruction telling contributors to keep the two in sync. Without it, the duplication will silently drift as `ci.yml` evolves, and the documented contract will lose its authority.

# Solution:

Append a new `### Drift Management` subsection to the end of the existing `## CI Contract` section in `CLAUDE.md`. The paragraph:

- Enumerates the five values duplicated from `ci.yml` (threshold, status-check string, trigger branches, workflow name, job name).
- States that any PR changing those values in `ci.yml` MUST also update the matching rows in `CLAUDE.md` in the same PR.
- Marks the rule as process-only, not tooling-enforced — reviewers are the enforcement mechanism (FR-006 AC-2; vision C2).

Alternatives considered and rejected: reverting `ci.yml` to `main`-only triggers (Option B) — rejected because the workflow already correctly triggers on both `main` and `develop`, so the gap is documentation, not behavior. Only additions are made; no existing lines are edited or removed.

# Testing

| Check | Result |
|---|---|
| `grep -c '^## CI Contract$' CLAUDE.md` | `1` |
| `grep -c '^### Drift Management$' CLAUDE.md` | `1` |
| `git diff -- .github/` | empty (0 lines) |
| `git diff HEAD -- ':!CLAUDE.md' ':!docs/'` | empty (0 lines) |
| Structural verification matrix (see `docs/DLPXECO-14142-test-evidence.md`) | all PASS |
| CI-equivalent: `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s` | exit 0; total coverage `2.3%` (≥ `2%` threshold) |

No new Go tests are added — the ticket adds no Go code. The existing `ci / unit-tests` job continues to gate this PR.

# Implementation:

- Single additive subsection appended at the end of the existing `## CI Contract` section in `CLAUDE.md`.
- Insertion point: immediately after the `### Branch Protection` subsection's status-check callout (per design §"Insertion Point").
- Wording uses uppercase "MUST" to match the convention already used in `CLAUDE.md` (e.g. the "Commits must be signed" line under Contribution Notes).

# Notes To Reviewers:

- Review the diff against the immediate parent commit, not against `origin/main` — this branch sits on top of the merged DLPXECO-14141 work, so a `vs origin/main` view will surface unrelated predecessor files.
- The change touches only `CLAUDE.md` (+ the `docs/DLPXECO-14142-*.md` spec artifacts). `.github/workflows/ci.yml`, `README.md`, `pull_request_template.md`, and everything under `internal/` and `examples/` are byte-unchanged.

# Future work:

None. If `ci.yml` adds new tracked values in the future, the drift rule itself will require updating the Workflow Summary table at that time.
