### PR TITLE
DLPXECO-14121: document CI test + coverage gate contract in CLAUDE.md…

### DIFF
--- a/.claude/test/testing.md
+++ b/.claude/test/testing.md
@@ -9,6 +9,25 @@ This provider has two distinct test tiers. Both run via the Terraform Plugin SDK
 | Unit | `make test` | Schema validation, helper functions, regex/utility code, provider-level checks (no remote calls) | None | Yes |
 | Acceptance | `TF_ACC=1 make testacc` | Full CRUD against a live DCT instance — provisions/deletes real resources | Live DCT + Delphix engines | No (requires credentials) |
 
+## CI-Enforced Gate 
+
+PRs to `main` or `develop` are blocked by the `ci / unit-tests` GitHub Actions check.
+Three rules apply:
+
+1. **Every PR runs the unit-test suite** — CI executes
+   `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s`
+   (the local equivalent is `make test`; CI uses a 300 s timeout vs. `make test`'s 30 s).
+
+2. **Coverage must not drop below 2%** — the `COVERAGE_THRESHOLD` env var in
+   `.github/workflows/ci.yml` is currently set to `2`. Adding or modifying code
+   without a corresponding unit test can lower the total and fail CI. The baseline
+   when the gate was set was 2.3% (measured 2026-06-06, unit tests only, no
+   `TF_ACC`). Do not lower the threshold without team agreement.
+
+3. **Acceptance tests are NOT run in CI** — `TestAcc*` tests are skipped
+   automatically because CI does not export `TF_ACC=1`. Run them locally before
+   submitting: `TF_ACC=1 make testacc`.
+
 ## Required Environment Variables
 
 > **Source of truth:** All env vars required by tests are declared in [`.claude/settings.local.json`](../settings.local.json) under the `env` block. Populate that file with your sandbox values — the file is gitignored so credentials stay local. The harness loads these into the shell environment for every test run. **Do not commit credentials inline in test files or in CI configs without an injected secret store.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,26 @@ configure GitHub.
 
 **The exact status-check string to enter in GitHub's branch protection UI is: `ci / unit-tests`**
 
+### CI Gates
+
+Three rules enforced on every PR targeting `main` or `develop`:
+
+1. **Unit-test workflow runs on every PR** — CI executes
+   `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s`
+   (the local equivalent is `make test`, though CI uses 300 s vs. `make test`'s
+   30 s timeout). The workflow must pass before a PR can be merged.
+
+2. **Coverage gate** — if total unit-test coverage drops below **2%**
+   (the `COVERAGE_THRESHOLD` in `ci.yml`), the `ci / unit-tests` check fails.
+   Adding or modifying a feature without a corresponding unit test will lower
+   coverage and block the PR. Raise the threshold — never lower it — when
+   adding new coverage.
+
+3. **Acceptance tests are NOT enforced in CI** — `TestAcc*` tests require a
+   live DCT instance and are excluded automatically because CI does not set
+   `TF_ACC=1`. Run them locally with `TF_ACC=1 make testacc` before marking
+   a feature complete.
+
 ### Drift Management
 
 The values in the Workflow Summary table above (threshold, status-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,14 +17,34 @@ This project operates under the Delphix Code of Conduct. By participating in thi
 All pull requests to `main` or `develop` must pass the `ci / unit-tests` GitHub Actions check before merging.
 The check runs automatically when you open or update a PR.
 
+### CI Gates
+
+Three rules are enforced on every PR:
+
+1. **Unit-test workflow runs on every PR** — CI runs
+   `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s`
+   against your branch. The workflow must pass before the PR can be merged
+   (the local equivalent is `make test`, though CI uses a 300 s timeout).
+
+2. **Coverage gate** — total unit-test coverage must stay at or above **2%**
+   (the current `COVERAGE_THRESHOLD` in `.github/workflows/ci.yml`). If your
+   change adds or modifies code without a corresponding unit test, coverage may
+   drop and the `ci / unit-tests` check will fail. Every feature or bugfix
+   should include at least one unit test.
+
+3. **Acceptance tests are NOT enforced in CI** — tests whose names start with
+   `TestAcc` require a live DCT instance and are excluded automatically because
+   CI does not set `TF_ACC=1`. Run them locally before marking your work done:
+   `TF_ACC=1 make testacc`.
+
 ### What the CI Check Does
 
 1. Checks out your branch at the PR commit SHA.
 2. Installs Go (version auto-detected from `go.mod`).
 3. Runs `go test ./... -coverprofile=coverage.out -covermode=atomic -timeout=300s`.
 4. Uploads `coverage.out` as a downloadable artifact (7-day retention).
-5. Fails if total coverage falls below the configured threshold
-   (see `COVERAGE_THRESHOLD` in `.github/workflows/ci.yml`).
+5. Fails if total coverage falls below **2%**
+   (`COVERAGE_THRESHOLD` in `.github/workflows/ci.yml`).
 
 ### Verifying Locally Before Pushing
 


### PR DESCRIPTION
…, CONTRIBUTING.md, and testing.md

Add an explicit "CI Gates" subsection to CLAUDE.md's existing CI Contract section, expand CONTRIBUTING.md's CI section with the same three-rule summary (including the 2% threshold value), and add a new "CI-Enforced Gate" section to .claude/test/testing.md. All three files now state consistently: (1) every PR runs go test ./...; (2) coverage must not drop below 2%; (3) acceptance tests are not run in CI.

<!--
# Context:
A clear description of the high level effort that this pull request is
a part of. Anyone in the organization can see this change and may not
have the same context as you.
-->
# Problem:
<!--
A clear description of the problem. The problem statement should be
written in terms of a specific symptom that affects users or the
business. The problem statement should not be written in terms of the
solution.
-->
# Solution:
<!--
A clear description of the high-level solution you have chosen. If
there were other possible solutions that you considered and rejected,
please mention those as well. Please do not describe implementation
details when writing about the solution, those should go into the
implementation section.
-->
# Testing
<!--
Describe explicitly how this change was tested. Were we able to
recreate the issue? Were we able to write a test case that failed
before that passes now?
-->
<!--
# Implementation:
The implementation details of the solution.
-->
<!--
# Notes To Reviewers:
Any extra information a reviewer may need to know before reviewing
your change. For example here you might want to describe which files
should be looked at first or which files are auto-generated.
-->
<!--
# Deployment Plan:
Some changes get more complicated and may need changes in multiple
repositories or may require infrastructure changes. Describe how these
changes will be smoothly deployed.
-->
<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
